### PR TITLE
Proof-of-concept for custom network adapters

### DIFF
--- a/examples/async/store/configureStore.js
+++ b/examples/async/store/configureStore.js
@@ -3,10 +3,15 @@ import thunkMiddleware from 'redux-thunk'
 import createLogger from 'redux-logger'
 import rootReducer from '../reducers'
 import { queryMiddleware } from 'redux-query'
+import networkAdapter from 'redux-query/dist/commonjs/adapters/superagent'
 
 const createStoreWithMiddleware = applyMiddleware(
   thunkMiddleware,
-  queryMiddleware((state) => state.queries, (state) => state.entities),
+  queryMiddleware(
+    (state) => state.queries,
+    (state) => state.entities,
+    networkAdapter,
+  ),
   createLogger()
 )(createStore)
 

--- a/src/adapters/superagent.js
+++ b/src/adapters/superagent.js
@@ -1,0 +1,45 @@
+import superagent from 'superagent';
+import * as httpMethods from '../constants/http-methods';
+
+const createRequest = (url, method) => {
+    switch (method) {
+        case httpMethods.GET:
+            return superagent.get(url);
+        case httpMethods.POST:
+            return superagent.post(url);
+        case httpMethods.PUT:
+            return superagent.put(url);
+        case httpMethods.DELETE:
+            return superagent.del(url);
+        default:
+            return;
+    }
+};
+
+const superagentNetworkAdapter = (url, method, body) => {
+    const request = createRequest(url, method);
+
+    if (!request) {
+        console.error(`Unsupported HTTP method: ${method}`);
+        return;
+    }
+
+    if (body) {
+        request.send(body);
+    }
+
+    const execute = (cb) => request.end((err, response) => {
+        const resOk = !!(response && response.ok);
+        const resStatus = (response && response.status) || 0;
+        const resBody = (response && response.body) || undefined;
+        const resText = (response && response.text) || undefined;
+
+        return cb(err, resOk, resStatus, resBody, resText);
+    });
+
+    const abort = () => request.abort();
+
+    return { execute, abort };
+};
+
+export default superagentNetworkAdapter;

--- a/test/middlewares/query.test.js
+++ b/test/middlewares/query.test.js
@@ -5,6 +5,7 @@ import superagentMock from 'superagent-mock';
 import * as actionTypes from '../../src/constants/action-types';
 import getQueryKey from '../../src/lib/get-query-key';
 import queryMiddleware from '../../src/middleware/query';
+import networkAdapter from '../../src/adapters/superagent';
 
 const apiMessage = 'hello, world!';
 const mockEndpoint = (match, data) => {
@@ -68,7 +69,11 @@ describe('query middleware', () => {
             const entitiesSelector = (state) => state.entities;
             const dispatch = () => {};
             const getState = () => {};
-            nextHandler = queryMiddleware(queriesSelector, entitiesSelector)({ dispatch, getState });
+            nextHandler = queryMiddleware(
+                queriesSelector,
+                entitiesSelector,
+                networkAdapter,
+            )({ dispatch, getState });
         });
 
         it('must return a next handler', () => {
@@ -117,7 +122,11 @@ describe('query middleware', () => {
                 entities: {},
                 queries: {},
             });
-            const nextHandler = queryMiddleware(queriesSelector, entitiesSelector)({ dispatch, getState });
+            const nextHandler = queryMiddleware(
+                queriesSelector,
+                entitiesSelector,
+                networkAdapter,
+            )({ dispatch, getState });
             const actionHandler = nextHandler();
             actionHandler({
                 type: actionTypes.REQUEST_ASYNC,
@@ -152,7 +161,11 @@ describe('query middleware', () => {
                 entities: {},
                 queries: {},
             });
-            const nextHandler = queryMiddleware(queriesSelector, entitiesSelector)({ dispatch, getState });
+            const nextHandler = queryMiddleware(
+                queriesSelector,
+                entitiesSelector,
+                networkAdapter,
+            )({ dispatch, getState });
             const actionHandler = nextHandler();
             actionHandler({
                 type: actionTypes.REQUEST_ASYNC,
@@ -178,7 +191,11 @@ describe('query middleware', () => {
                     },
                 },
             });
-            const nextHandler = queryMiddleware(queriesSelector, entitiesSelector)({ dispatch, getState });
+            const nextHandler = queryMiddleware(
+                queriesSelector,
+                entitiesSelector,
+                networkAdapter,
+            )({ dispatch, getState });
             const actionHandler = nextHandler();
             const requestAction = actionHandler({
                 type: actionTypes.REQUEST_ASYNC,
@@ -206,7 +223,11 @@ describe('query middleware', () => {
                     },
                 },
             });
-            const nextHandler = queryMiddleware(queriesSelector, entitiesSelector)({ dispatch, getState });
+            const nextHandler = queryMiddleware(
+                queriesSelector,
+                entitiesSelector,
+                networkAdapter,
+            )({ dispatch, getState });
             const actionHandler = nextHandler();
             actionHandler({
                 type: actionTypes.REQUEST_ASYNC,
@@ -245,7 +266,11 @@ describe('query middleware', () => {
                     },
                 },
             });
-            const nextHandler = queryMiddleware(queriesSelector, entitiesSelector)({ dispatch, getState });
+            const nextHandler = queryMiddleware(
+                queriesSelector,
+                entitiesSelector,
+                networkAdapter,
+            )({ dispatch, getState });
             const actionHandler = nextHandler();
             actionHandler({
                 type: actionTypes.REQUEST_ASYNC,
@@ -284,7 +309,11 @@ describe('query middleware', () => {
                     },
                 },
             });
-            const nextHandler = queryMiddleware(queriesSelector, entitiesSelector)({ dispatch, getState });
+            const nextHandler = queryMiddleware(
+                queriesSelector,
+                entitiesSelector,
+                networkAdapter,
+            )({ dispatch, getState });
             const actionHandler = nextHandler();
             actionHandler({
                 type: actionTypes.REQUEST_ASYNC,
@@ -322,7 +351,11 @@ describe('query middleware', () => {
                 entities: {},
                 queries: {},
             });
-            const nextHandler = queryMiddleware(queriesSelector, entitiesSelector)({ dispatch, getState });
+            const nextHandler = queryMiddleware(
+                queriesSelector,
+                entitiesSelector,
+                networkAdapter,
+            )({ dispatch, getState });
             const actionHandler = nextHandler();
             actionHandler({
                 type: actionTypes.MUTATE_ASYNC,
@@ -357,7 +390,11 @@ describe('query middleware', () => {
                 entities: {},
                 queries: {},
             });
-            const nextHandler = queryMiddleware(queriesSelector, entitiesSelector)({ dispatch, getState });
+            const nextHandler = queryMiddleware(
+                queriesSelector,
+                entitiesSelector,
+                networkAdapter,
+            )({ dispatch, getState });
             const actionHandler = nextHandler();
             actionHandler({
                 type: actionTypes.MUTATE_ASYNC,
@@ -396,7 +433,11 @@ describe('query middleware', () => {
                 },
                 queries: {},
             });
-            const nextHandler = queryMiddleware(queriesSelector, entitiesSelector)({ dispatch, getState });
+            const nextHandler = queryMiddleware(
+                queriesSelector,
+                entitiesSelector,
+                networkAdapter,
+            )({ dispatch, getState });
             const actionHandler = nextHandler();
             actionHandler({
                 type: actionTypes.MUTATE_ASYNC,
@@ -437,7 +478,11 @@ describe('query middleware', () => {
                 },
                 queries: {},
             });
-            const nextHandler = queryMiddleware(queriesSelector, entitiesSelector)({ dispatch, getState });
+            const nextHandler = queryMiddleware(
+                queriesSelector,
+                entitiesSelector,
+                networkAdapter,
+            )({ dispatch, getState });
             const actionHandler = nextHandler();
             actionHandler({
                 type: actionTypes.MUTATE_ASYNC,
@@ -477,7 +522,11 @@ describe('query middleware', () => {
                 },
             });
             const next = () => {};
-            const nextHandler = queryMiddleware(queriesSelector, entitiesSelector)({ dispatch, getState });
+            const nextHandler = queryMiddleware(
+                queriesSelector,
+                entitiesSelector,
+                networkAdapter,
+            )({ dispatch, getState });
             const actionHandler = nextHandler(next);
             actionHandler({
                 type: actionTypes.CANCEL_QUERY,
@@ -507,7 +556,11 @@ describe('query middleware', () => {
                 },
             });
             const next = () => {};
-            const nextHandler = queryMiddleware(queriesSelector, entitiesSelector)({ dispatch, getState });
+            const nextHandler = queryMiddleware(
+                queriesSelector,
+                entitiesSelector,
+                networkAdapter,
+            )({ dispatch, getState });
             const actionHandler = nextHandler(next);
             actionHandler({
                 type: actionTypes.CANCEL_QUERY,
@@ -547,7 +600,11 @@ describe('query middleware', () => {
                     },
                 },
             });
-            const nextHandler = queryMiddleware(queriesSelector, entitiesSelector)({ dispatch, getState });
+            const nextHandler = queryMiddleware(
+                queriesSelector,
+                entitiesSelector,
+                networkAdapter,
+            )({ dispatch, getState });
             const actionHandler = nextHandler(next);
             actionHandler({
                 type: actionTypes.RESET,


### PR DESCRIPTION
As the title states, this just a simple example which adds the ability to inject a network adapter to the milddleware. I'm adding this mostly to open up the discussion of this feature.

With this feature, we could create our own adapter to set headers/auth, or to even use a different request library in place of SuperAgent.

The idea is to update the `queryMiddleware`'s signature so that an adapter is passed as the 3rd argument. The "adapter" in this example is a function that accepts three args:

* `url`
* `method`
* `body` (optional)

The adapter will return an object with two properties, both of which contain functions:

* `execute`
* `abort`

The `execute` function requires a callback, which will receive (at this moment) the following args:

* `err`
* `resOk`
* `resStatus`
* `resBody`
* `resText`

The main adapter function is called by the middleware and the returned object is then used to call and cancel requests.

The `execute` function's return args mirror the original variables that were used in the middleware, but we'll likely want to remove the `resOk` argument in order to simplify the API. We could just ensure the status code is 2xx instead.

Tests are passing, and the async example project is working with this POC, however there might be more I'm missing since I haven't read through the entire source.

Anyway, let me know your thoughts on this type of feature.