### PR TITLE
Allow setting headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ Query configs are objects used to describe how redux-query should handle the req
 | `force` | boolean |  | Perform the request even if we've already successfully requested it. |
 | `queryKey` | string |  | The identifier used to identify the query metadata in the `queries` reducer. If unprovided, the `url` and `body` fields are serialized to generate the query key. |
 | `meta` | object |  | Various metadata for the query. Can be used to update other reducers when queries succeed or fail. |
-| `options` | object |  | Options for the request. Set `options.method` to change the HTTP method. |
+| `options` | object |  | Options for the request. Set `options.method` to change the HTTP method, and `options.headers` to set any headers. |
 
 #### Mutation query config options
 
@@ -91,7 +91,7 @@ Query configs are objects used to describe how redux-query should handle the req
 | `optimisticUpdate` | object |  | Object where keys are entity IDs and values are functions that provide the current entity value. The return values are used to update the `entities` store until the mutation finishes. |
 | `body` | object |  | The HTTP request body. |
 | `queryKey` | string |  | The identifier used to identify the query metadata in the `queries` reducer. If unprovided, the `url` and `body` fields are serialized to generate the query key. |
-| `options` | object |  | Options for the request. Set `options.method` to change the HTTP method. |
+| `options` | object |  | Options for the request. Set `options.method` to change the HTTP method, and `options.headers` to set any headers. |
 
 ### `transform` functions
 

--- a/examples/async/containers/App.js
+++ b/examples/async/containers/App.js
@@ -110,6 +110,11 @@ function getSchema(reddit) {
 const AppContainer = connectRequest((props) => ({
     url: getRedditUrl(props.selectedReddit),
     transform: (response) => normalize(response, getSchema(props.selectedReddit)).entities,
+    options: {
+      headers: {
+        Accept: "application/json"
+      }
+    },
     update: {
       posts: (prevPosts, posts) => {
         return {

--- a/src/middleware/query.js
+++ b/src/middleware/query.js
@@ -193,6 +193,7 @@ const queryMiddleware = (queriesSelector, entitiesSelector, config = defaultConf
                     queryKey: providedQueryKey,
                     body,
                     optimisticUpdate,
+                    options = {},
                 } = action;
                 invariant(!!url, 'Missing required `url` field in action handler');
 
@@ -208,7 +209,11 @@ const queryMiddleware = (queriesSelector, entitiesSelector, config = defaultConf
                 returnValue = new Promise((resolve) => {
                     const start = new Date();
                     const request = superagent.post(url);
-
+                    
+                    if (options.headers) {
+                        request.set(options.headers);
+                    }
+                    
                     // Note: only the entities that are included in `optimisticUpdate` will be passed along in the
                     // `mutateStart` action as `optimisticEntities`
                     dispatch(mutateStart(url, body, request, optimisticEntities, queryKey));

--- a/src/middleware/query.js
+++ b/src/middleware/query.js
@@ -119,6 +119,10 @@ const queryMiddleware = (queriesSelector, entitiesSelector, config = defaultConf
                         if (body) {
                             request.send(body);
                         }
+                        
+                        if (options.headers) {
+                            request.set(options.headers);
+                        }
 
                         let attempts = 0;
                         const backoff = new Backoff({

--- a/test/middlewares/query.test.js
+++ b/test/middlewares/query.test.js
@@ -31,22 +31,22 @@ const mockEndpoint = (match, data) => {
 const superagentMockConfig = [
     {
         pattern: '/echo-headers',
-        fixtures: (match, params, headers, context) => {
+        fixtures: (match, params, headers) => {
             return headers;
         },
         get: (match, data) => {
             return {
                 body: {
-                    message: data
+                    message: data,
                 },
                 status: 200,
-                ok: true
-            }
-        }
+                ok: true,
+            };
+        },
     },
     {
         pattern: '/(\\w+)',
-        fixtures: (match, params, headers, context) => {
+        fixtures: () => {
             return apiMessage;
         },
         get: mockEndpoint,
@@ -182,11 +182,11 @@ describe('query middleware', () => {
         
         it('should use headers if provided as an option', (done) => {
             const url = '/echo-headers';
-            const headers = {"x-message": apiMessage};
+            const headers = { 'x-message': apiMessage };
             const actionsToDispatch = [
                 {
                     type: actionTypes.REQUEST_START,
-                    url
+                    url,
                 },
                 {
                     type: actionTypes.REQUEST_SUCCESS,
@@ -208,7 +208,7 @@ describe('query middleware', () => {
                 type: actionTypes.REQUEST_ASYNC,
                 url,
                 options: {
-                    headers
+                    headers,
                 },
                 update: {
                     message: (prevMessage, message) => message,


### PR DESCRIPTION
Addresses #3 by allowing users to set `options.headers` in `connectRequest`.