### PR TITLE
Exchange react-pure-render dependency with react-addons-shallow-compare 

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "lodash.pickby": "^4.6.0",
     "lodash.values": "^4.3.0",
     "react": "^15.0.1",
-    "react-pure-render": "^1.0.2",
+    "react-addons-shallow-compare": "^15.4.2",
     "superagent": "^1.6.1"
   },
   "peerDependencies": {

--- a/src/components/connect-request.js
+++ b/src/components/connect-request.js
@@ -2,7 +2,7 @@ import partial from 'lodash.partial';
 import difference from 'lodash.difference';
 import intersection from 'lodash.intersection';
 import React from 'react';
-import shallowEqual from 'react-pure-render/shallowEqual';
+import shallowCompare from 'react-addons-shallow-compare';
 
 import { requestAsync, cancelQuery } from '../actions';
 import getQueryKey from '../lib/get-query-key';
@@ -41,7 +41,7 @@ const connectRequest = (mapPropsToConfigs, options = {}) => (WrappedComponent) =
 
         shouldComponentUpdate(nextProps, nextState) {
             if (pure) {
-                return !shallowEqual(this.props, nextProps) || !shallowEqual(this.state, nextState);
+                return !shallowCompare(this, nextProps, nextState);
             } else {
                 return true;
             }

--- a/src/components/connect-request.js
+++ b/src/components/connect-request.js
@@ -41,7 +41,7 @@ const connectRequest = (mapPropsToConfigs, options = {}) => (WrappedComponent) =
 
         shouldComponentUpdate(nextProps, nextState) {
             if (pure) {
-                return !shallowCompare(this, nextProps, nextState);
+                return shallowCompare(this, nextProps, nextState);
             } else {
                 return true;
             }


### PR DESCRIPTION
Hi,

thanks for this awesome library. The library works great with react, but I was not able to use it with react-native due to the react-pure-render dependency. For this reason I replaced the react-pure-render dependency with react-addons-shallow-compare.

All the best,

Martin