### PR TITLE
Include credentials for CORS

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ Query configs are objects used to describe how redux-query should handle the req
 | `force` | boolean |  | Perform the request even if we've already successfully requested it. |
 | `queryKey` | string |  | The identifier used to identify the query metadata in the `queries` reducer. If unprovided, the `url` and `body` fields are serialized to generate the query key. |
 | `meta` | object |  | Various metadata for the query. Can be used to update other reducers when queries succeed or fail. |
-| `options` | object |  | Options for the request. Set `options.method` to change the HTTP method, and `options.headers` to set any headers. |
+| `options` | object |  | Options for the request. Set `options.method` to change the HTTP method, `options.headers` to set any headers and `options.credentias = 'include'` for CORS. |
 
 #### Mutation query config options
 
@@ -91,7 +91,7 @@ Query configs are objects used to describe how redux-query should handle the req
 | `optimisticUpdate` | object |  | Object where keys are entity IDs and values are functions that provide the current entity value. The return values are used to update the `entities` store until the mutation finishes. |
 | `body` | object |  | The HTTP request body. |
 | `queryKey` | string |  | The identifier used to identify the query metadata in the `queries` reducer. If unprovided, the `url` and `body` fields are serialized to generate the query key. |
-| `options` | object |  | Options for the request. Set `options.method` to change the HTTP method, and `options.headers` to set any headers. |
+| `options` | object |  | Options for the request. Set `options.method` to change the HTTP method, `options.headers` to set any headers and `options.credentias = 'include'` for CORS. |
 
 ### `transform` functions
 

--- a/src/middleware/query.js
+++ b/src/middleware/query.js
@@ -129,6 +129,10 @@ const queryMiddleware = (queriesSelector, entitiesSelector, config = defaultConf
                             request.set(options.headers);
                         }
 
+                        if (options.credentials === 'include') {
+                            request.withCredentials();
+                        }
+
                         let attempts = 0;
                         const backoff = new Backoff({
                             min: config.backoff.minDuration,
@@ -224,6 +228,10 @@ const queryMiddleware = (queriesSelector, entitiesSelector, config = defaultConf
 
                     if (options.headers) {
                         request.set(options.headers);
+                    }
+
+                    if (options.credentials === 'include') {
+                        request.withCredentials();
                     }
 
                     // Note: only the entities that are included in `optimisticUpdate` will be passed along in the


### PR DESCRIPTION
- Respects `credentials` fields on options obejct
- Updates README

I've decided to make `credentials` be a string, not a boolean. To be more compliant with fetch API, especially when we are considering on supporting custom adapters.