### PR TITLE
Added response body and text to request/mutate success/failure

### DIFF
--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -11,7 +11,7 @@ export const requestStart = (url, body, request, meta, queryKey) => {
     };
 };
 
-export const requestSuccess = (url, body, status, entities, meta, queryKey) => {
+export const requestSuccess = (url, body, status, entities, meta, queryKey, resBody, resText) => {
     return {
         type: actionTypes.REQUEST_SUCCESS,
         url,
@@ -21,10 +21,12 @@ export const requestSuccess = (url, body, status, entities, meta, queryKey) => {
         meta,
         queryKey,
         time: Date.now(),
+        resBody,
+        resText,
     };
 };
 
-export const requestFailure = (url, body, status, responseBody, meta, queryKey) => {
+export const requestFailure = (url, body, status, responseBody, meta, queryKey, resBody, resText) => {
     return {
         type: actionTypes.REQUEST_FAILURE,
         url,
@@ -34,6 +36,8 @@ export const requestFailure = (url, body, status, responseBody, meta, queryKey) 
         meta,
         queryKey,
         time: Date.now(),
+        resBody,
+        resText,
     };
 };
 
@@ -48,7 +52,7 @@ export const mutateStart = (url, body, request, optimisticEntities, queryKey) =>
     };
 };
 
-export const mutateSuccess = (url, body, status, entities, queryKey) => {
+export const mutateSuccess = (url, body, status, entities, queryKey, resBody, resText) => {
     return {
         type: actionTypes.MUTATE_SUCCESS,
         url,
@@ -57,10 +61,12 @@ export const mutateSuccess = (url, body, status, entities, queryKey) => {
         entities,
         queryKey,
         time: Date.now(),
+        resBody,
+        resText,
     };
 };
 
-export const mutateFailure = (url, body, status, originalEntities, queryKey) => {
+export const mutateFailure = (url, body, status, originalEntities, queryKey, resBody, resText) => {
     return {
         type: actionTypes.MUTATE_FAILURE,
         url,
@@ -69,6 +75,8 @@ export const mutateFailure = (url, body, status, originalEntities, queryKey) => 
         originalEntities,
         queryKey,
         time: Date.now(),
+        resBody,
+        resText,
     };
 };
 

--- a/src/middleware/query.js
+++ b/src/middleware/query.js
@@ -170,9 +170,10 @@ const queryMiddleware = (queriesSelector, entitiesSelector, config = defaultConf
                                             url,
                                             body,
                                             resStatus,
-                                            resBody,
                                             meta,
-                                            queryKey
+                                            queryKey,
+                                            resBody,
+                                            resText
                                         )
                                     );
                                 } else {
@@ -180,7 +181,18 @@ const queryMiddleware = (queriesSelector, entitiesSelector, config = defaultConf
                                     const entities = entitiesSelector(callbackState);
                                     transformed = transform(resBody, resText);
                                     newEntities = updateEntities(update, entities, transformed);
-                                    dispatch(requestSuccess(url, body, resStatus, newEntities, meta, queryKey));
+                                    dispatch(
+                                        requestSuccess(
+                                            url,
+                                            body,
+                                            resStatus,
+                                            newEntities,
+                                            meta,
+                                            queryKey,
+                                            resBody,
+                                            resText
+                                        )
+                                    );
                                 }
 
                                 const end = new Date();
@@ -250,11 +262,11 @@ const queryMiddleware = (queriesSelector, entitiesSelector, config = defaultConf
                         let newEntities;
 
                         if (err || !resOk) {
-                            dispatch(mutateFailure(url, body, resStatus, entities, queryKey));
+                            dispatch(mutateFailure(url, body, resStatus, entities, queryKey, resBody, resText));
                         } else {
                             transformed = transform(resBody, resText);
                             newEntities = updateEntities(update, entities, transformed);
-                            dispatch(mutateSuccess(url, body, resStatus, newEntities, queryKey));
+                            dispatch(mutateSuccess(url, body, resStatus, newEntities, queryKey, resBody, resText));
                         }
 
                         const end = new Date();

--- a/src/reducers/queries.js
+++ b/src/reducers/queries.js
@@ -37,6 +37,8 @@ const queries = (state = initialState, action) => {
                     isPending: false,
                     lastUpdated: action.time,
                     status: action.status,
+                    resBody: action.resBody,
+                    resText: action.resText,
                 },
             };
         }

--- a/src/selectors/query.js
+++ b/src/selectors/query.js
@@ -38,6 +38,30 @@ export const status = (urlOrConfig, body) => (queriesState) => {
     return get(queriesState, [queryKey, 'status']);
 };
 
+export const resBody = (urlOrConfig, body) => (queriesState) => {
+    let queryKey;
+
+    if (typeof urlOrConfig === 'string') {
+        queryKey = reconcileQueryKey({ url: urlOrConfig, body });
+    } else {
+        queryKey = reconcileQueryKey(urlOrConfig);
+    }
+
+    return get(queriesState, [queryKey, 'resBody']);
+};
+
+export const resText = (urlOrConfig, body) => (queriesState) => {
+    let queryKey;
+
+    if (typeof urlOrConfig === 'string') {
+        queryKey = reconcileQueryKey({ url: urlOrConfig, body });
+    } else {
+        queryKey = reconcileQueryKey(urlOrConfig);
+    }
+
+    return get(queriesState, [queryKey, 'resText']);
+};
+
 export const lastUpdated = (urlOrConfig, body) => (queriesState) => {
     let queryKey;
 


### PR DESCRIPTION
As a developer, in order to communicate errors properly in my application, I'd like to have access to the original response in the query state.