### PR TITLE
fix 'npm install' on Windows - do not enforce 'unix' line endings

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -41,7 +41,6 @@
         "indent": [2, 4, { "SwitchCase": 1 }],
         "jsx-quotes": [2, "prefer-double"],
         "keyword-spacing": [2, {"before": true, "after": true, "overrides": {}}],
-        "linebreak-style": 2,
         "lines-around-comment": [2, { "beforeBlockComment": true, "allowBlockStart": true }],
         "max-len": [2, 120, 4],
         "new-parens": 2,


### PR DESCRIPTION
Before purposed change Webpack fails @ linting:
> error  Expected linebreaks to be 'LF' but found 'CRLF'  linebreak-style
> ✖ 1993 problems (1993 errors, 0 warnings)

After removing 'linebreak-style' rule build is successful.