### PR TITLE
Possible stale store is passed into update call for mutate

### DIFF
--- a/src/middleware/query-advanced.js
+++ b/src/middleware/query-advanced.js
@@ -187,10 +187,10 @@ const queryMiddlewareAdvanced = (networkAdapter) => (queriesSelector, entitiesSe
                 } = action;
                 invariant(!!url, 'Missing required `url` field in action handler');
 
-                const state = getState();
-                const entities = entitiesSelector(state);
                 let optimisticEntities;
                 if (optimisticUpdate) {
+                    const state = getState();
+                    const entities = entitiesSelector(state);
                     optimisticEntities = optimisticUpdateEntities(optimisticUpdate, entities);
                 }
 
@@ -213,6 +213,9 @@ const queryMiddlewareAdvanced = (networkAdapter) => (queriesSelector, entitiesSe
                     request.execute((err, resStatus, resBody, resText, resHeaders) => {
                         let transformed;
                         let newEntities;
+
+                        const state = getState();
+                        const entities = entitiesSelector(state);
 
                         if (err || !resOk(resStatus)) {
                             dispatch(mutateFailure(


### PR DESCRIPTION
If two mutation requests (2 create with sync ids that get updated to object ids on success in our case), only the last mutation saves.