### PR TITLE
pass the responseBody through to the state

### DIFF
--- a/src/reducers/queries.js
+++ b/src/reducers/queries.js
@@ -37,6 +37,7 @@ const queries = (state = initialState, action) => {
                     isPending: false,
                     lastUpdated: action.time,
                     status: action.status,
+                    responseBody: action.responseBody,
                 },
             };
         }

--- a/src/selectors/query.js
+++ b/src/selectors/query.js
@@ -61,3 +61,15 @@ export const queryCount = (urlOrConfig, body) => (queriesState) => {
 
     return get(queriesState, [queryKey, 'queryCount']);
 };
+
+export const responseBody = (urlOrConfig, body) => (queriesState) => {
+    let queryKey;
+
+    if (typeof urlOrConfig === 'string') {
+        queryKey = reconcileQueryKey({ url: urlOrConfig, body });
+    } else {
+        queryKey = reconcileQueryKey(urlOrConfig);
+    }
+
+    return get(queriesState, [queryKey, 'responseBody']);
+};

--- a/test/selectors/query.test.js
+++ b/test/selectors/query.test.js
@@ -218,4 +218,47 @@ describe('query selectors', () => {
             assert.equal(queryCount, 2);
         });
     });
+
+    describe('responseBody', () => {
+        it('should work with just url', () => {
+            const responseBody = querySelectors.responseBody('/api/dashboards')({
+                '{"url":"/api/dashboards"}': {
+                    responseBody: { some: 'json' },
+                },
+            });
+            assert.deepEqual(responseBody, { some: 'json' });
+        });
+
+        it('should work with a config', () => {
+            const queryConfig = {
+                url: '/api/dashboard/1/rename',
+                body: {
+                    name: 'My KPIs',
+                },
+            };
+            const queryKey = getQueryKey(queryConfig.url, queryConfig.body);
+            const responseBody = querySelectors.responseBody(queryConfig)({
+                [queryKey]: {
+                    responseBody: { some: 'json' },
+                },
+            });
+            assert.deepEqual(responseBody, { some: 'json' });
+        });
+
+        it('should work with a config with a queryKey field', () => {
+            const queryConfig = {
+                url: '/api/dashboard/1/rename',
+                body: {
+                    name: 'My KPIs',
+                },
+                queryKey: 'myQueryKey',
+            };
+            const responseBody = querySelectors.responseBody(queryConfig)({
+                myQueryKey: {
+                    responseBody: { some: 'json' },
+                },
+            });
+            assert.deepEqual(responseBody, { some: 'json' });
+        });
+    });
 });


### PR DESCRIPTION
I looked around a bit and wasn't able to find any examples of error handling, so passing the responseBody through to the query state (and adding a corresponding selector) made it much simpler to access error messages when there's a REQUEST_FAILURE or MUTATE_FAILURE.

With this change I can have something like

```js
error: querySelectors.status(url)(state.queries) > 400 && querySelectors.responseBody(url)(state.queries)
```

in my `mapStateToProps` and then `this.props.error` is either `false` if no error occurred, or the server's response if one did. might even be nice to take this a step further and add a selector to combine the two, but I figured keeping it simple for now was probably best.