### PR TITLE
Moved react from dependencies to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,6 @@
     "lodash.partial": "^4.2.1",
     "lodash.pickby": "^4.6.0",
     "lodash.values": "^4.3.0",
-    "react": "^15.0.1",
     "react-addons-shallow-compare": "^15.4.2",
     "superagent": "^1.6.1"
   },
@@ -71,6 +70,7 @@
     "eslint-plugin-react": "^6.1.1",
     "mocha": "^2.4.5",
     "nyc": "^10.0.0",
+    "react": "^15.0.1",
     "rimraf": "^2.4.3",
     "superagent-mock": "^1.10.0",
     "webpack": "^1.9.6"


### PR DESCRIPTION
Hi,

React is already present as a `peerDependency`, which is good.
We don't need it as an explicit direct dependency.

I'm using React Native 0.43.0-rc.3 which works with React 16.0.0-alpha.3.
So ended up with 2 different React version in my node_modules.

Also I've got another PR coming which itself fixes another issue when you try to use redux-query with React Native. As seen in https://github.com/amplitude/redux-query/issues/32

Let me know what you think.