### PR TITLE
Fix error with React Native's Packager

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,4 +1,5 @@
 *.lcov
+.babelrc
 .nyc_output
 coverage
 examples


### PR DESCRIPTION
Hi there

I'm using React Native (0.43.0-rc.3) and initially got the error message reported in https://github.com/amplitude/redux-query/issues/32 when I tried to use redux-query with it.

The reason why it happens is React Native's packager tries to transpile packages in node_modules and if one of the package has a `.babelrc` config, it tries to use it.
Here since I don't have the presets used by redux-query (`"react", "es2015", "stage-2"`) in my main project dependencies, it fails.

One fix is not to ship the `.babelrc` file as part of the npm package so it doesn't confuse RN's packager.

Note that in the future RN will stop transpiling node_modules so this won't be a problem anymore.
See https://github.com/facebook/react-native/issues/10966

Let me know what you think.