### PR TITLE
v2.0.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ dist
 node_modules
 npm-debug.log
 .vscode
+.DS_Store

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,21 @@
+## 2.0.0
+
+Refer to the [v2 transition guide](https://github.com/amplitude/redux-query/blob/master/docs/transition-guides/v2.md) for instructions on how to upgrade from redux-query 1.x to 2.x.
+
+- Use the latest entities state when the network request finishes for mutations
+- Replace `request` fields in queries reducer and relevant actions with `networkHandler`
+- New, safer rollback behavior when mutations fail
+- New `rollback` option in query configs to handle reverting optimistic updates 
+- New, optional reducer, `errorsReducer`, for tracking response bodies, text, and headers for failed queries
+- Change `connectRequest` to work around a race condition resulting in invalid warnings
+- Update to superagent 3.x
+- Avoid creating new functions in connectRequest's render function (acontreras89 [#67](https://github.com/amplitude/redux-query/pull/67))
+- Replace `removeEntity` and `removeEntities` actions with a more generic `updateEntities` action
+- Remove `reconcileQueryKey` and change `getQueryKey` to only accept query config objects as a parameter
+- Replace usage of deprecated `react-addons-shallow-compare`
+- Renamed "network adapters" to "network interfaces"
+- Some top-level exports have been removed or renamed (see v2 transition guide for more information)
+
 ## 1.5.0
 
 - Use prop-types to avoid React 15.5.0 deprecation warnings (ryanashcraft)

--- a/README.md
+++ b/README.md
@@ -265,6 +265,11 @@ The result of the promise returned by `mutateAsync` will be the following object
 | body | object or null | Parsed response body.
 | text | string | Unparsed response body string.
 | duration | number | The total duration from the start of the query to receiving the full response.
+
+When the mutation succeeds, it will also include the following fields:
+
+| Name | Type | Description |
+|:-----|:-----|:-----|
 | transformed | any | Result from the transform function. Will be identical to body if transform is unprovided in the query config.
 | entities | object | The new, updated entities that have been affected by the query.
 

--- a/README.md
+++ b/README.md
@@ -272,11 +272,28 @@ The result of the promise returned by `mutateAsync` will be the following object
 
 Similarly to how mutations are triggered by dispatching `mutateAsync` actions, you can trigger requests by dispatching `requestAsync` actions with a request query config.
 
-### `redux-query/advanced` and custom network interfaces
+### Custom network interfaces
 
-By default, `redux-query` makes XHR requests using the [superagent](https://github.com/visionmedia/superagent) library. If you'd rather use a different library for making requests, you can use the `redux-query`'s "advanced" mode by importing from `redux-query/advanced` instead of `redux-query`.
+By default, `redux-query` makes XHR requests using the [superagent](https://github.com/visionmedia/superagent) library. If you'd rather use a different library for making requests, you can use `redux-query`'s `queryMiddlewareAdvanced` middleware.
+
+If you use a custom network interface and want to avoid including superagent in your bundle, change all of your imports from `redux-query` to `redux-query/advanced`.
 
 Note: The default [`queryMiddleware`](./src/middleware/query.js) exported from the main `redux-query` entry point is simply a [superagent network interface](./src/network-interfaces/superagent.js) bound to `queryMiddlewareAdvanced`.
+
+Network interfaces have the following interface:
+
+```javascript
+type NetworkInterface = (
+    url: string,
+    method: 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE',
+    config?: { body?: string | Object, headers?: Object, credentials?: 'omit' | 'include' } = {},
+) => NetworkHandler;
+
+type NetworkHandler = {
+    execute: (callback: (err: any, resStatus: number, resBody: ?Object, resText: string, resHeaders: Object) => void) => void,
+    abort: () => void,
+};
+```
 
 Example `queryMiddlewareAdvanced` usage:
 
@@ -300,23 +317,6 @@ const store = createStore(
     reducer,
     applyMiddleware(queryMiddlewareAdvanced(myNetworkInterface)(getQueries, getEntities))
 );
-```
-
-#### Network interfaces
-
-You must provide a function to `queryMiddlewareAdvanced` that adheres to the following interface:
-
-```javascript
-type NetworkInterface = (
-    url: string,
-    method: 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE',
-    config?: { body?: string | Object, headers?: Object, credentials?: 'omit' | 'include' } = {},
-) => NetworkHandler;
-
-type NetworkHandler = {
-    execute: (callback: (err: any, resStatus: number, resBody: ?Object, resText: string, resHeaders: Object) => void) => void,
-    abort: () => void,
-};
 ```
 
 ## Example

--- a/README.md
+++ b/README.md
@@ -293,7 +293,7 @@ You can also Promise-chain on dispatched `requestAsync` actions, but a Promise w
 
 All of the query selectors have the following signature:
 
-`(queryConfig) => (queriesReducerState) => mixed`
+`(queriesReducerState, queryConfig) => mixed`
 
 ### Errors reducer and selectors
 
@@ -311,7 +311,7 @@ You can query from this state using the provided `errorSelectors`:
 
 All of the query selectors have the following signature:
 
-`(queryConfig) => (errorsReducerState) => mixed`
+`(errorsReducerState, queryConfig) => mixed`
 
 ### Custom network interfaces
 

--- a/README.md
+++ b/README.md
@@ -277,7 +277,7 @@ When the mutation succeeds, it will also include the following fields:
 
 Similarly to how mutations are triggered by dispatching `mutateAsync` actions, you can trigger requests by dispatching `requestAsync` actions with a request query config.
 
-You can also Promise-chain on dispatched `requestAsync` actions, but a Promise will only be returned if `redux-query` determines it will make a network request. For example, if the query config not have `force` set to `true` and a previous request with the same query key previously succeeded, then a Promise will not be returned. So be sure to always check that the returned value from a dispatched `requestAsync` is a Promise before interacting with it.
+You can also Promise-chain on dispatched `requestAsync` actions, but a Promise will only be returned if `redux-query` determines it will make a network request. For example, if the query config does not have `force` set to `true` and a previous request with the same query key previously succeeded, then a Promise will not be returned. So be sure to always check that the returned value from a dispatched `requestAsync` is a Promise before interacting with it.
 
 ### Queries selectors
 

--- a/README.md
+++ b/README.md
@@ -277,6 +277,8 @@ When the mutation succeeds, it will also include the following fields:
 
 Similarly to how mutations are triggered by dispatching `mutateAsync` actions, you can trigger requests by dispatching `requestAsync` actions with a request query config.
 
+You can also Promise-chain on dispatched `requestAsync` actions, but a Promise will only be returned if `redux-query` determines it will make a network request. For example, if the query config not have `force` set to `true` and a previous request with the same query key previously succeeded, then a Promise will not be returned. So be sure to always check that the returned value from a dispatched `requestAsync` is a Promise before interacting with it.
+
 ### Queries selectors
 
 `redux-query` provides some useful selectors for reading from the queries reducer state:

--- a/README.md
+++ b/README.md
@@ -272,11 +272,11 @@ The result of the promise returned by `mutateAsync` will be the following object
 
 Similarly to how mutations are triggered by dispatching `mutateAsync` actions, you can trigger requests by dispatching `requestAsync` actions with a request query config.
 
-### `redux-query/advanced` and custom network adapters
+### `redux-query/advanced` and custom network interfaces
 
 By default, `redux-query` makes XHR requests using the [superagent](https://github.com/visionmedia/superagent) library. If you'd rather use a different library for making requests, you can use the `redux-query`'s "advanced" mode by importing from `redux-query/advanced` instead of `redux-query`.
 
-Note: The default [`queryMiddleware`](./src/middleware/query.js) exported from the main `redux-query` entry point is simply a [superagent adapter](./src/adapters/superagent.js) bound to `queryMiddlewareAdvanced`.
+Note: The default [`queryMiddleware`](./src/middleware/query.js) exported from the main `redux-query` entry point is simply a [superagent network interface](./src/network-interfaces/superagent.js) bound to `queryMiddlewareAdvanced`.
 
 Example `queryMiddlewareAdvanced` usage:
 
@@ -286,7 +286,7 @@ import { entitiesReducer, queriesReducer, queryMiddlewareAdvanced } from 'redux-
 
 // A function that takes a url, method, and other options. This function should return an object
 // with two required properties: execute and abort.
-import myNetworkAdapter from './network-adapter';
+import myNetworkInterface from './network-interface';
 
 export const getQueries = (state) => state.queries;
 export const getEntities = (state) => state.entities;
@@ -298,25 +298,24 @@ const reducer = combineReducers({
 
 const store = createStore(
     reducer,
-    applyMiddleware(queryMiddlewareAdvanced(myNetworkAdapter)(getQueries, getEntities))
+    applyMiddleware(queryMiddlewareAdvanced(myNetworkInterface)(getQueries, getEntities))
 );
 ```
 
-#### Network adapters
+#### Network interfaces
 
-You must provide a function to `queryMiddlewareAdvanced` that adheres to the following `NetworkAdapter` interface:
+You must provide a function to `queryMiddlewareAdvanced` that adheres to the following interface:
 
 ```javascript
-type NetworkAdapter = (
+type NetworkInterface = (
     url: string,
     method: 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE',
     config?: { body?: string | Object, headers?: Object, credentials?: 'omit' | 'include' } = {},
-) => NetworkRequest;
+) => NetworkHandler;
 
-type NetworkRequest = {
+type NetworkHandler = {
     execute: (callback: (err: any, resStatus: number, resBody: ?Object, resText: string, resHeaders: Object) => void) => void,
     abort: () => void,
-    instance: any,
 };
 ```
 

--- a/README.md
+++ b/README.md
@@ -272,6 +272,40 @@ The result of the promise returned by `mutateAsync` will be the following object
 
 Similarly to how mutations are triggered by dispatching `mutateAsync` actions, you can trigger requests by dispatching `requestAsync` actions with a request query config.
 
+### Queries selectors
+
+`redux-query` provides some useful selectors for reading from the queries reducer state:
+
+| Selector Name | Return Type | Description |
+|:-----|:-----|:-----|
+| isFinished | ?boolean | Returns `true` if the query was resolved or cancelled.
+| isPending | ?boolean | Returns `true` if the query is in-flight – not resolved and not cancelled.
+| status | ?number | Response HTTP status code.
+| lastUpdated | ?number | Time at which the query was resolved.
+| queryCount | ?number | Number of times a query was started with the same query key.
+
+All of the query selectors have the following signature:
+
+`(queryConfig) => (queriesReducerState) => mixed`
+
+### Errors reducer and selectors
+
+`redux-query` provides another reducer for applications that want to track response body, text, and headers in redux state. Unlike the entities and queries reducers, `errorsReducer` is totally optional. If you include this reducer in your application's combined reducer, all responses from requests and mutations with non-2xx status codes will be recorded in this state.
+
+Note: If your application has many queries that could potentially error and is used for long periods of time, you should avoid using this reducer as it could potentially accumulate a lot of memory usage. You can alternatively build your own reducer to track a subset of queries, or rely on the promise interface to handle error responses in an ad-hoc manor.
+
+You can query from this state using the provided `errorSelectors`:
+
+| Selector Name | Return Type | Description |
+|:-----|:-----|:-----|
+| responseBody | ?Object | Parsed response body (if query failed).
+| responseText | ?string | Unparsed response body string (if query failed).
+| responseHeaders | ?Object | Response headers (if query failed).
+
+All of the query selectors have the following signature:
+
+`(queryConfig) => (errorsReducerState) => mixed`
+
 ### Custom network interfaces
 
 By default, `redux-query` makes XHR requests using the [superagent](https://github.com/visionmedia/superagent) library. If you'd rather use a different library for making requests, you can use `redux-query`'s `queryMiddlewareAdvanced` middleware.

--- a/docs/transition-guides/v2.md
+++ b/docs/transition-guides/v2.md
@@ -1,0 +1,99 @@
+# Important things to know
+
+## superagent has been updated to 3.x
+
+Any code that relied on the older version may need to be updated.
+
+## Mutations have a subtly different behavior when updating entities
+
+Motivation:
+
+With redux-query 1.x, if you have simultaneous mutations that update the same entity, you could end up in with one mutation completely overwriting the changes of the other one. This is because the entities state for the update is captured before the network request starts, as opposed to when it finishes. Naturally, this has confused several people and just feels wrong.
+
+Solution:
+
+With redux-query 2.x, mutations behave more like requests when it comes to how the entities state is used when updating. `transform`s and `update`s will always be passed the latest entities state.
+
+Breaking changes:
+
+- Logic depending on the previous behavior will break and need to be updated.
+- The returned value to the promise on mutation failures no longer include the "entities" field.
+
+## New rollback behavior for optimistically-updated entities
+
+Motivation:
+
+With redux-query 1.x, mutation failures blindly revert the entire entities state. This shouldn't have much impact for apps that don't have many mutations going on simultaneously, but it's obviously a suboptimal and dangerous behavior.
+
+Solution:
+
+Rollbacks are now handled on a per-entity basis. By default we'll simply revert all optimistically-updated entities back to their previous value before the optimistic update. All entities without an optimistic update handler will be unaffected.
+
+Additionally, we now offer a custom hook in query configs to enable manual control of the rollback logic. This will enable you to safely support simultaneous mutations for the same entity when using optimistic update. It'll be important that apps consider providing a rollback handler whenever an entity is partially updated by multiple, possibly-simultaneous mutations.
+
+See the README for more information on the `rollback` field.
+
+## New optional reducer for tracking failed query response data
+
+redux-query 2 exports a new reducer `errorsReducer` and accompanying set of selectors, `errorSelectors`. See the README for more information.
+
+# Other actions to take
+
+## Update all references to `request` field in actions and queries state
+
+The `request` fields in the start actions and stored in the queries reducer state has been removed in favor of a new field  called `networkHandler`.
+
+`networkHandler` is the returned value from the network interface, not the underlying superagent instance. When using redux-query in its default mode with the superagent network interface, you can get the superagent instance with `networkHandler.instance`.
+
+## Replace `removeEntity`/`REMOVE_ENTITY` and `removeEntities`/`REMOVE_ENTITIES` with `updateEntities`/`UPDATE_ENTITIES`
+
+`REMOVE_ENTITY` and `REMOVE_ENTITIES` actions have been replaced with a more generic UPDATE_ENTITIES action.
+
+Example:
+
+```javascript
+import { removeEntity } from 'redux-query';
+
+dispatch(removeEntity(['dashboardsById', '78dhr8v']));
+```
+
+becomes:
+
+```javascript
+import omit from 'lodash.omit';
+import { updateEntities } from 'redux-query';
+
+dispatch(updateEntities({
+    dashboards: (value) => omit(value, '78dhr8v'),
+}));
+```
+
+## Update all references to `reconcileQueryKey` and `getQueryKey`
+
+`reconcileQueryKey` and `getQueryKey` have been combined into a single function: `getQueryKey`. This function no longer accepts separate `url` and `body` parameters – instead you must pass a query config (or query-config-like object).
+
+Example:
+
+```javascript
+import { getQueryKey } from 'redux-query';
+const queryKey = getQueryKey(query.url, query.body);
+```
+
+becomes:
+
+```javascript
+import { getQueryKey } from 'redux-query';
+const queryKey = getQueryKey(query);
+```
+
+## Update all references to `querySelectors`
+
+All selectors in `querySelectors` have changed their signatures. The queries state is now the first argument, with a query config (or query-config-like object) as the second parameter.
+
+## Replace imports of `actions`, as it's no longer exported
+
+If you were importing `actions` from redux-query, you should change to import the actions directly. The only supported actions that are exported are: `cancelQuery`, `mutateAsync`, `requestAsync`, and `updateEntities`.
+
+## Rename "adapters" to "network interfaces"
+
+This is not a breaking change, but if you use `queryMiddlewareAdvanced` – I recommend renaming any references to "adapters" to prevent future confusion.

--- a/docs/transition-guides/v2.md
+++ b/docs/transition-guides/v2.md
@@ -1,14 +1,16 @@
-# Important things to know
+# redux-query 1.x to 2.x Transition Guide
 
-## superagent has been updated to 3.x
+## Important things to know
+
+### superagent has been updated to 3.x
 
 Any code that relied on the older version may need to be updated.
 
-## Mutations have a subtly different behavior when updating entities
+### Mutations have a subtly different behavior when updating entities
 
 Motivation:
 
-With redux-query 1.x, if you have simultaneous mutations that update the same entity, you could end up in with one mutation completely overwriting the changes of the other one. This is because the entities state for the update is captured before the network request starts, as opposed to when it finishes. Naturally, this has confused several people and just feels wrong.
+With redux-query 1.x, if you have simultaneous mutations that update the same entity, you could end up in with one mutation completely overwriting the changes of the other one. This is because the entities state for the update is captured before the network request starts, as opposed to when it finishes.
 
 Solution:
 
@@ -19,7 +21,7 @@ Breaking changes:
 - Logic depending on the previous behavior will break and need to be updated.
 - The returned value to the promise on mutation failures no longer include the "entities" field.
 
-## New rollback behavior for optimistically-updated entities
+### New rollback behavior for optimistically-updated entities
 
 Motivation:
 
@@ -33,23 +35,23 @@ Additionally, we now offer a custom hook in query configs to enable manual contr
 
 See the README for more information on the `rollback` field.
 
-## New optional reducer for tracking failed query response data
+### New optional reducer for tracking failed query response data
 
 redux-query 2 exports a new reducer `errorsReducer` and accompanying set of selectors, `errorSelectors`. See the README for more information.
 
-# Other actions to take
+## Other actions to take
 
-## Update all references to `request` field in actions and queries state
+### Update all references to `request` field in actions and queries state
 
 The `request` fields in the start actions and stored in the queries reducer state has been removed in favor of a new field  called `networkHandler`.
 
 `networkHandler` is the returned value from the network interface, not the underlying superagent instance. When using redux-query in its default mode with the superagent network interface, you can get the superagent instance with `networkHandler.instance`.
 
-## Replace `removeEntity`/`REMOVE_ENTITY` and `removeEntities`/`REMOVE_ENTITIES` with `updateEntities`/`UPDATE_ENTITIES`
+### Replace `removeEntity` and `removeEntities` with `updateEntities`
 
 `REMOVE_ENTITY` and `REMOVE_ENTITIES` actions have been replaced with a more generic UPDATE_ENTITIES action.
 
-Example:
+For example, the following 1.x redux-query usage:
 
 ```javascript
 import { removeEntity } from 'redux-query';
@@ -68,11 +70,11 @@ dispatch(updateEntities({
 }));
 ```
 
-## Update all references to `reconcileQueryKey` and `getQueryKey`
+### Update all references to `reconcileQueryKey` and `getQueryKey`
 
 `reconcileQueryKey` and `getQueryKey` have been combined into a single function: `getQueryKey`. This function no longer accepts separate `url` and `body` parameters – instead you must pass a query config (or query-config-like object).
 
-Example:
+For example, the following 1.x redux-query usage:
 
 ```javascript
 import { getQueryKey } from 'redux-query';
@@ -86,14 +88,14 @@ import { getQueryKey } from 'redux-query';
 const queryKey = getQueryKey(query);
 ```
 
-## Update all references to `querySelectors`
+### Update all references to `querySelectors`
 
 All selectors in `querySelectors` have changed their signatures. The queries state is now the first argument, with a query config (or query-config-like object) as the second parameter.
 
-## Replace imports of `actions`, as it's no longer exported
+### Replace imports of `actions`, as it's no longer exported
 
 If you were importing `actions` from redux-query, you should change to import the actions directly. The only supported actions that are exported are: `cancelQuery`, `mutateAsync`, `requestAsync`, and `updateEntities`.
 
-## Rename "adapters" to "network interfaces"
+### Rename "adapters" to "network interfaces"
 
 This is not a breaking change, but if you use `queryMiddlewareAdvanced` – I recommend renaming any references to "adapters" to prevent future confusion.

--- a/examples/async/package.json
+++ b/examples/async/package.json
@@ -21,11 +21,11 @@
     "react-redux": "^4.0.0",
     "redux": "^3.0.0",
     "redux-logger": "^2.0.2",
+    "redux-query": "../..",
     "redux-thunk": "^1.0.0"
   },
   "devDependencies": {
     "expect": "^1.6.0",
-    "react-scripts": "0.9.3",
-    "redux-query": "1.3.1-alpha.0"
+    "react-scripts": "0.9.3"
   }
 }

--- a/examples/async/src/containers/App.js
+++ b/examples/async/src/containers/App.js
@@ -69,8 +69,8 @@ const mapStateToProps = state => {
   const { selectedReddit } = state;
   const url = getRedditUrl(selectedReddit);
   const queriesState = get(state, 'queries');
-  const isFetching = querySelectors.isPending(url)(queriesState) || false;
-  const lastUpdated = querySelectors.lastUpdated(url)(queriesState);
+  const isFetching = querySelectors.isPending(queriesState, { url }) || false;
+  const lastUpdated = querySelectors.lastUpdated(queriesState, { url });
   const postIds = get(
     state,
     ['entities', 'reddits', selectedReddit, 'data', 'children'],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "redux-query",
-  "version": "2.0.0-alpha.3",
+  "version": "2.0.0-alpha.4",
   "description": "A library for querying and managing network state in React/Redux applications",
   "homepage": "https://github.com/amplitude/redux-query",
   "main": "dist/commonjs/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "redux-query",
-  "version": "2.0.0-alpha.4",
+  "version": "2.0.0-rc.1",
   "description": "A library for querying and managing network state in React/Redux applications",
   "homepage": "https://github.com/amplitude/redux-query",
   "main": "dist/commonjs/index.js",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,6 @@
     "lodash.includes": "^4.3.0",
     "lodash.intersection": "^4.4.0",
     "lodash.omit": "^4.5.0",
-    "lodash.partial": "^4.2.1",
     "lodash.pick": "^4.4.0",
     "lodash.pickby": "^4.6.0",
     "lodash.values": "^4.3.0",

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "lodash.intersection": "^4.4.0",
     "lodash.omit": "^4.5.0",
     "lodash.partial": "^4.2.1",
+    "lodash.pick": "^4.4.0",
     "lodash.pickby": "^4.6.0",
     "lodash.values": "^4.3.0",
     "prop-types": "^15.5.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "redux-query",
-  "version": "1.5.0",
+  "version": "2.0.0-alpha.0",
   "description": "A library for querying and managing network state in React/Redux applications",
   "homepage": "https://github.com/amplitude/redux-query",
   "main": "dist/commonjs/index.js",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,6 @@
     "lodash.pickby": "^4.6.0",
     "lodash.values": "^4.3.0",
     "prop-types": "^15.5.6",
-    "react-addons-shallow-compare": "^15.4.2",
     "superagent": "^3.5.1"
   },
   "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -40,7 +40,6 @@
   "author": "Ryan Ashcraft <ryan@amplitude.com>",
   "license": "MIT",
   "dependencies": {
-    "asap": "^2.0.5",
     "backo": "^1.1.0",
     "invariant": "^2.2.0",
     "json-stable-stringify": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "redux-query",
-  "version": "2.0.0-rc.1",
+  "version": "2.0.0-rc.2",
   "description": "A library for querying and managing network state in React/Redux applications",
   "homepage": "https://github.com/amplitude/redux-query",
   "main": "dist/commonjs/index.js",

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "gh-pages": "^0.12.0",
     "mocha": "^2.4.5",
     "nyc": "^10.0.0",
-    "prettier": "^0.21.0",
+    "prettier": "^1.3.1",
     "react": "^15.0.1",
     "rimraf": "^2.4.3",
     "superagent-mock": "^3.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "redux-query",
-  "version": "2.0.0-alpha.1",
+  "version": "2.0.0-alpha.2",
   "description": "A library for querying and managing network state in React/Redux applications",
   "homepage": "https://github.com/amplitude/redux-query",
   "main": "dist/commonjs/index.js",

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "lodash.values": "^4.3.0",
     "prop-types": "^15.5.6",
     "react-addons-shallow-compare": "^15.4.2",
-    "superagent": "^1.6.1"
+    "superagent": "^3.5.1"
   },
   "peerDependencies": {
     "react": "^0.14.0 || ^15.0.0-0",
@@ -82,7 +82,7 @@
     "prettier": "^0.21.0",
     "react": "^15.0.1",
     "rimraf": "^2.4.3",
-    "superagent-mock": "^1.10.0",
+    "superagent-mock": "^3.3.0",
     "webpack": "^1.9.6"
   }
 }

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "lodash.values": "^4.3.0",
     "prop-types": "^15.5.6",
     "react-addons-shallow-compare": "^15.4.2",
+    "setimmediate": "^1.0.5",
     "superagent": "^1.6.1"
   },
   "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "redux-query",
-  "version": "2.0.0-alpha.2",
+  "version": "2.0.0-alpha.3",
   "description": "A library for querying and managing network state in React/Redux applications",
   "homepage": "https://github.com/amplitude/redux-query",
   "main": "dist/commonjs/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "redux-query",
-  "version": "2.0.0-alpha.0",
+  "version": "2.0.0-alpha.1",
   "description": "A library for querying and managing network state in React/Redux applications",
   "homepage": "https://github.com/amplitude/redux-query",
   "main": "dist/commonjs/index.js",

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
   "author": "Ryan Ashcraft <ryan@amplitude.com>",
   "license": "MIT",
   "dependencies": {
+    "asap": "^2.0.5",
     "backo": "^1.1.0",
     "invariant": "^2.2.0",
     "json-stable-stringify": "^1.0.0",
@@ -54,7 +55,6 @@
     "lodash.values": "^4.3.0",
     "prop-types": "^15.5.6",
     "react-addons-shallow-compare": "^15.4.2",
-    "setimmediate": "^1.0.5",
     "superagent": "^1.6.1"
   },
   "peerDependencies": {

--- a/site/.gitignore
+++ b/site/.gitignore
@@ -8,6 +8,7 @@
 
 # production
 /build
+/public/vendor
 
 # misc
 .DS_Store

--- a/site/package.json
+++ b/site/package.json
@@ -34,6 +34,6 @@
     "prebuild": "npm run lint",
     "start": "npm run vendor && react-scripts start",
     "test": "react-scripts test --env=jsdom",
-    "vendor": "mkdir -p public/vendor && cp node_modules/redux-query/dist/umd/redux-query.js public/vendor/redux-query.js"
+    "vendor": "npm i redux-query && mkdir -p public/vendor && cp node_modules/redux-query/dist/umd/redux-query.js public/vendor/redux-query.js"
   }
 }

--- a/site/package.json
+++ b/site/package.json
@@ -26,13 +26,14 @@
     "react-scripts": "0.9.3"
   },
   "scripts": {
-    "build": "react-scripts build",
+    "build": "npm run vendor && react-scripts build",
     "clean": "rimraf build",
     "eject": "react-scripts eject",
     "lint:demos": "eslint src --fix --ext .js.txt",
     "lint": "eslint src --fix --ext .js && npm run lint:demos",
     "prebuild": "npm run lint",
-    "start": "react-scripts start",
-    "test": "react-scripts test --env=jsdom"
+    "start": "npm run vendor && react-scripts start",
+    "test": "react-scripts test --env=jsdom",
+    "vendor": "mkdir -p public/vendor && cp node_modules/redux-query/dist/umd/redux-query.js public/vendor/redux-query.js"
   }
 }

--- a/site/src/components/ResultFrame.js
+++ b/site/src/components/ResultFrame.js
@@ -61,7 +61,6 @@ class ResultFrame extends Component {
       'https://cdnjs.cloudflare.com/ajax/libs/babel-core/5.8.25/browser-polyfill.min.js',
       'https://unpkg.com/redux-saga@0.14/dist/redux-saga.min.js',
       'https://unpkg.com/qs@6.0.4/dist/qs.js',
-      'https://unpkg.com/redux-query@1.5.0-alpha.1/dist/umd/redux-query.js',
       '/vendor/redux-query.js',
     ];
 

--- a/site/src/components/ResultFrame.js
+++ b/site/src/components/ResultFrame.js
@@ -85,7 +85,7 @@ class ResultFrame extends Component {
           var isExternalUrl = url.indexOf('://') > 0 || url.indexOf('//') === 0;
 
           if (isExternalUrl) {
-            return ReduxQuery.superagentNetworkInterface.apply(ReduxQuery.networkInterfaces.superagent, arguments);
+            return ReduxQuery.networkInterfaces.superagent.apply(ReduxQuery.networkInterfaces.superagent, arguments);
           }
 
           var aborted = false;

--- a/site/src/components/ResultFrame.js
+++ b/site/src/components/ResultFrame.js
@@ -81,11 +81,11 @@ class ResultFrame extends Component {
     );
     contentWindow.document.write(
       `<script type="text/javascript">
-        var mockAdapter = function(url, method, config) {
+        var mockNetworkInterface = function(url, method, config) {
           var isExternalUrl = url.indexOf('://') > 0 || url.indexOf('//') === 0;
 
           if (isExternalUrl) {
-            return ReduxQuery.superagentAdapter.apply(ReduxQuery.superagentAdapter, arguments);
+            return ReduxQuery.superagentNetworkInterface.apply(ReduxQuery.networkInterfaces.superagent, arguments);
           }
 
           var aborted = false;
@@ -129,7 +129,7 @@ class ResultFrame extends Component {
         };
 
         ReduxQuery = Object.assign({}, ReduxQuery, {
-          queryMiddleware: ReduxQuery.queryMiddlewareAdvanced(mockAdapter),
+          queryMiddleware: ReduxQuery.queryMiddlewareAdvanced(mockNetworkInterface),
         });
       </script>`
     );

--- a/site/src/components/ResultFrame.js
+++ b/site/src/components/ResultFrame.js
@@ -62,6 +62,7 @@ class ResultFrame extends Component {
       'https://unpkg.com/redux-saga@0.14/dist/redux-saga.min.js',
       'https://unpkg.com/qs@6.0.4/dist/qs.js',
       'https://unpkg.com/redux-query@1.5.0-alpha.1/dist/umd/redux-query.js',
+      '/vendor/redux-query.js',
     ];
 
     const contentWindow = this._iframeRef.contentWindow;

--- a/site/src/demos/hacker-news/client.js.txt
+++ b/site/src/demos/hacker-news/client.js.txt
@@ -135,7 +135,7 @@ const ItemContainer = compose(
   connect((state, props) => {
     const query = itemRequest(props.itemId);
     return {
-      isLoading: querySelectors.isPending(query)(state.queries),
+      isLoading: querySelectors.isPending(state.queries, query),
       item: selectItem(state, props),
       query,
     };

--- a/site/src/demos/mounting/client.js.txt
+++ b/site/src/demos/mounting/client.js.txt
@@ -92,7 +92,7 @@ class HelloWorld extends Component {
 // Map redux state to props. This is ordinary react-redux usage – we're just
 // reading from the entities state.
 const mapStateToProps = state => ({
-  isLoading: querySelectors.isPending(helloRequest())(state.queries),
+  isLoading: querySelectors.isPending(state.queries, helloRequest()),
   message: state.entities.message,
 });
 

--- a/site/src/demos/redux-saga/client.js.txt
+++ b/site/src/demos/redux-saga/client.js.txt
@@ -31,7 +31,7 @@ import {
   mutateAsync,
   requestAsync,
   cancelQuery,
-  reconcileQueryKey,
+  getQueryKey,
 } from 'redux-query';
 import createSagaMiddleware, { takeLatest } from 'redux-saga';
 import { cancelled, put } from 'redux-saga/effects';
@@ -163,7 +163,7 @@ function* changeName(action) {
     if (yield cancelled()) {
       // When this saga is cancelled because another CHANGE_NAME action was
       // dispatched, we can cancel the in-flight query here.
-      yield put(cancelQuery(reconcileQueryKey(query)));
+      yield put(cancelQuery(getQueryKey(query)));
     }
   }
 }

--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -177,16 +177,9 @@ export const cancelQuery = queryKey => {
     };
 };
 
-export const removeEntity = path => {
+export const updateEntities = update => {
     return {
-        type: actionTypes.REMOVE_ENTITY,
-        path,
-    };
-};
-
-export const removeEntities = paths => {
-    return {
-        type: actionTypes.REMOVE_ENTITIES,
-        paths,
+        type: actionTypes.UPDATE_ENTITIES,
+        update,
     };
 };

--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -1,11 +1,11 @@
 import * as actionTypes from '../constants/action-types';
 
-export const requestStart = (url, body, request, meta, queryKey) => {
+export const requestStart = (url, body, networkHandler, meta, queryKey) => {
     return {
         type: actionTypes.REQUEST_START,
         url,
         body,
-        request,
+        networkHandler,
         meta,
         queryKey,
     };
@@ -52,12 +52,12 @@ export const requestFailure = (url, body, status, responseBody, meta, queryKey, 
     };
 };
 
-export const mutateStart = (url, body, request, optimisticEntities, queryKey, meta) => {
+export const mutateStart = (url, body, networkHandler, optimisticEntities, queryKey, meta) => {
     return {
         type: actionTypes.MUTATE_START,
         url,
         body,
-        request,
+        networkHandler,
         optimisticEntities,
         queryKey,
         meta,

--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -1,14 +1,6 @@
 import * as actionTypes from '../constants/action-types';
 
-export const requestStart = (
-    {
-        body,
-        meta,
-        networkHandler,
-        queryKey,
-        url,
-    }
-) => {
+export const requestStart = ({ body, meta, networkHandler, queryKey, url }) => {
     return {
         type: actionTypes.REQUEST_START,
         url,
@@ -19,19 +11,17 @@ export const requestStart = (
     };
 };
 
-export const requestSuccess = (
-    {
-        body,
-        entities,
-        meta,
-        queryKey,
-        responseBody,
-        responseHeaders,
-        responseText,
-        status,
-        url,
-    }
-) => {
+export const requestSuccess = ({
+    body,
+    entities,
+    meta,
+    queryKey,
+    responseBody,
+    responseHeaders,
+    responseText,
+    status,
+    url,
+}) => {
     return {
         type: actionTypes.REQUEST_SUCCESS,
         url,
@@ -47,18 +37,7 @@ export const requestSuccess = (
     };
 };
 
-export const requestFailure = (
-    {
-        body,
-        meta,
-        queryKey,
-        responseBody,
-        responseHeaders,
-        responseText,
-        status,
-        url,
-    }
-) => {
+export const requestFailure = ({ body, meta, queryKey, responseBody, responseHeaders, responseText, status, url }) => {
     return {
         type: actionTypes.REQUEST_FAILURE,
         url,
@@ -73,16 +52,7 @@ export const requestFailure = (
     };
 };
 
-export const mutateStart = (
-    {
-        body,
-        meta,
-        networkHandler,
-        optimisticEntities,
-        queryKey,
-        url,
-    }
-) => {
+export const mutateStart = ({ body, meta, networkHandler, optimisticEntities, queryKey, url }) => {
     return {
         type: actionTypes.MUTATE_START,
         url,
@@ -94,19 +64,17 @@ export const mutateStart = (
     };
 };
 
-export const mutateSuccess = (
-    {
-        body,
-        entities,
-        meta,
-        queryKey,
-        responseBody,
-        responseHeaders,
-        responseText,
-        status,
-        url,
-    }
-) => {
+export const mutateSuccess = ({
+    body,
+    entities,
+    meta,
+    queryKey,
+    responseBody,
+    responseHeaders,
+    responseText,
+    status,
+    url,
+}) => {
     return {
         type: actionTypes.MUTATE_SUCCESS,
         url,
@@ -122,19 +90,17 @@ export const mutateSuccess = (
     };
 };
 
-export const mutateFailure = (
-    {
-        body,
-        meta,
-        queryKey,
-        responseBody,
-        responseHeaders,
-        responseText,
-        rolledBackEntities,
-        status,
-        url,
-    }
-) => {
+export const mutateFailure = ({
+    body,
+    meta,
+    queryKey,
+    responseBody,
+    responseHeaders,
+    responseText,
+    rolledBackEntities,
+    status,
+    url,
+}) => {
     return {
         type: actionTypes.MUTATE_FAILURE,
         url,
@@ -150,20 +116,18 @@ export const mutateFailure = (
     };
 };
 
-export const requestAsync = (
-    {
-        body,
-        force,
-        meta,
-        options,
-        queryKey,
-        retry,
-        transform,
-        update,
-        url,
-        unstable_preDispatchCallback,
-    }
-) => {
+export const requestAsync = ({
+    body,
+    force,
+    meta,
+    options,
+    queryKey,
+    retry,
+    transform,
+    update,
+    url,
+    unstable_preDispatchCallback,
+}) => {
     return {
         type: actionTypes.REQUEST_ASYNC,
         body,
@@ -179,19 +143,7 @@ export const requestAsync = (
     };
 };
 
-export const mutateAsync = (
-    {
-        body,
-        meta,
-        optimisticUpdate,
-        options,
-        queryKey,
-        rollback,
-        transform,
-        update,
-        url,
-    }
-) => {
+export const mutateAsync = ({ body, meta, optimisticUpdate, options, queryKey, rollback, transform, update, url }) => {
     return {
         type: actionTypes.MUTATE_ASYNC,
         body,

--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -1,6 +1,14 @@
 import * as actionTypes from '../constants/action-types';
 
-export const requestStart = (url, body, networkHandler, meta, queryKey) => {
+export const requestStart = (
+    {
+        body,
+        meta,
+        networkHandler,
+        queryKey,
+        url,
+    }
+) => {
     return {
         type: actionTypes.REQUEST_START,
         url,
@@ -12,15 +20,17 @@ export const requestStart = (url, body, networkHandler, meta, queryKey) => {
 };
 
 export const requestSuccess = (
-    url,
-    body,
-    status,
-    entities,
-    meta,
-    queryKey,
-    responseBody,
-    responseText,
-    responseHeaders
+    {
+        body,
+        entities,
+        meta,
+        queryKey,
+        responseBody,
+        responseHeaders,
+        responseText,
+        status,
+        url,
+    }
 ) => {
     return {
         type: actionTypes.REQUEST_SUCCESS,
@@ -37,7 +47,18 @@ export const requestSuccess = (
     };
 };
 
-export const requestFailure = (url, body, status, responseBody, meta, queryKey, responseText, responseHeaders) => {
+export const requestFailure = (
+    {
+        body,
+        meta,
+        queryKey,
+        responseBody,
+        responseHeaders,
+        responseText,
+        status,
+        url,
+    }
+) => {
     return {
         type: actionTypes.REQUEST_FAILURE,
         url,
@@ -52,7 +73,16 @@ export const requestFailure = (url, body, status, responseBody, meta, queryKey, 
     };
 };
 
-export const mutateStart = (url, body, networkHandler, optimisticEntities, queryKey, meta) => {
+export const mutateStart = (
+    {
+        body,
+        meta,
+        networkHandler,
+        optimisticEntities,
+        queryKey,
+        url,
+    }
+) => {
     return {
         type: actionTypes.MUTATE_START,
         url,
@@ -65,15 +95,17 @@ export const mutateStart = (url, body, networkHandler, optimisticEntities, query
 };
 
 export const mutateSuccess = (
-    url,
-    body,
-    status,
-    entities,
-    queryKey,
-    responseBody,
-    responseText,
-    responseHeaders,
-    meta
+    {
+        body,
+        entities,
+        meta,
+        queryKey,
+        responseBody,
+        responseHeaders,
+        responseText,
+        status,
+        url,
+    }
 ) => {
     return {
         type: actionTypes.MUTATE_SUCCESS,
@@ -91,15 +123,17 @@ export const mutateSuccess = (
 };
 
 export const mutateFailure = (
-    url,
-    body,
-    status,
-    rolledBackEntities,
-    queryKey,
-    responseBody,
-    responseText,
-    responseHeaders,
-    meta
+    {
+        body,
+        meta,
+        queryKey,
+        responseBody,
+        responseHeaders,
+        responseText,
+        rolledBackEntities,
+        status,
+        url,
+    }
 ) => {
     return {
         type: actionTypes.MUTATE_FAILURE,

--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -161,6 +161,7 @@ export const requestAsync = (
         transform,
         update,
         url,
+        unstable_preDispatchCallback,
     }
 ) => {
     return {
@@ -174,6 +175,7 @@ export const requestAsync = (
         transform,
         update,
         url,
+        unstable_preDispatchCallback,
     };
 };
 

--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -99,7 +99,8 @@ export const mutateFailure = (
     responseBody,
     responseText,
     responseHeaders,
-    meta
+    meta,
+    entities
 ) => {
     return {
         type: actionTypes.MUTATE_FAILURE,
@@ -110,6 +111,7 @@ export const mutateFailure = (
         responseText,
         responseHeaders,
         originalEntities,
+        entities,
         queryKey,
         time: Date.now(),
         meta,
@@ -150,6 +152,7 @@ export const mutateAsync = (
         optimisticUpdate,
         options,
         queryKey,
+        rollback,
         transform,
         update,
         url,
@@ -162,6 +165,7 @@ export const mutateAsync = (
         optimisticUpdate,
         options,
         queryKey,
+        rollback,
         transform,
         update,
         url,

--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -94,13 +94,12 @@ export const mutateFailure = (
     url,
     body,
     status,
-    originalEntities,
+    rolledBackEntities,
     queryKey,
     responseBody,
     responseText,
     responseHeaders,
-    meta,
-    rolledBackEntities
+    meta
 ) => {
     return {
         type: actionTypes.MUTATE_FAILURE,
@@ -110,7 +109,6 @@ export const mutateFailure = (
         responseBody,
         responseText,
         responseHeaders,
-        originalEntities,
         rolledBackEntities,
         queryKey,
         time: Date.now(),

--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -100,7 +100,7 @@ export const mutateFailure = (
     responseText,
     responseHeaders,
     meta,
-    entities
+    rolledBackEntities
 ) => {
     return {
         type: actionTypes.MUTATE_FAILURE,
@@ -111,7 +111,7 @@ export const mutateFailure = (
         responseText,
         responseHeaders,
         originalEntities,
-        entities,
+        rolledBackEntities,
         queryKey,
         time: Date.now(),
         meta,

--- a/src/advanced.js
+++ b/src/advanced.js
@@ -5,7 +5,7 @@ import * as errorSelectors from './selectors/error';
 import * as querySelectors from './selectors/query';
 
 export { default as connectRequest } from './components/connect-request';
-export { getQueryKey, reconcileQueryKey } from './lib/query-key';
+export { getQueryKey } from './lib/query-key';
 export { default as queriesReducer } from './reducers/queries';
 export { default as entitiesReducer } from './reducers/entities';
 export { default as errorsReducer } from './reducers/errors';

--- a/src/advanced.js
+++ b/src/advanced.js
@@ -10,5 +10,5 @@ export { default as queriesReducer } from './reducers/queries';
 export { default as entitiesReducer } from './reducers/entities';
 export { default as errorsReducer } from './reducers/errors';
 export { default as queryMiddlewareAdvanced } from './middleware/query-advanced';
-export { cancelQuery, mutateAsync, requestAsync, removeEntities, removeEntity } from './actions';
+export { cancelQuery, mutateAsync, requestAsync, updateEntities } from './actions';
 export { actions, actionTypes, errorSelectors, httpMethods, querySelectors };

--- a/src/advanced.js
+++ b/src/advanced.js
@@ -1,12 +1,14 @@
 import * as actions from './actions';
 import * as actionTypes from './constants/action-types';
 import * as httpMethods from './constants/http-methods';
+import * as errorSelectors from './selectors/error';
 import * as querySelectors from './selectors/query';
 
 export { default as connectRequest } from './components/connect-request';
 export { getQueryKey, reconcileQueryKey } from './lib/query-key';
 export { default as queriesReducer } from './reducers/queries';
 export { default as entitiesReducer } from './reducers/entities';
+export { default as errorsReducer } from './reducers/errors';
 export { default as queryMiddlewareAdvanced } from './middleware/query-advanced';
 export { cancelQuery, mutateAsync, requestAsync, removeEntities, removeEntity } from './actions';
-export { actions, actionTypes, httpMethods, querySelectors };
+export { actions, actionTypes, errorSelectors, httpMethods, querySelectors };

--- a/src/advanced.js
+++ b/src/advanced.js
@@ -1,4 +1,3 @@
-import * as actions from './actions';
 import * as actionTypes from './constants/action-types';
 import * as httpMethods from './constants/http-methods';
 import * as errorSelectors from './selectors/error';
@@ -11,4 +10,4 @@ export { default as entitiesReducer } from './reducers/entities';
 export { default as errorsReducer } from './reducers/errors';
 export { default as queryMiddlewareAdvanced } from './middleware/query-advanced';
 export { cancelQuery, mutateAsync, requestAsync, updateEntities } from './actions';
-export { actions, actionTypes, errorSelectors, httpMethods, querySelectors };
+export { actionTypes, errorSelectors, httpMethods, querySelectors };

--- a/src/components/connect-request.js
+++ b/src/components/connect-request.js
@@ -106,7 +106,7 @@ const connectRequest = (mapPropsToConfigs, options = {}) => WrappedComponent => 
                         force,
                         retry,
                         ...config,
-                        unstable_preDispatchCallback() {
+                        unstable_preDispatchCallback: () => {
                             delete this._pendingRequests[queryKey];
                         },
                     })

--- a/src/components/connect-request.js
+++ b/src/components/connect-request.js
@@ -3,6 +3,7 @@ import includes from 'lodash.includes';
 import intersection from 'lodash.intersection';
 import React from 'react';
 import shallowCompare from 'react-addons-shallow-compare';
+import setImmediate from 'setimmediate';
 
 import { requestAsync, cancelQuery } from '../actions';
 import { reconcileQueryKey } from '../lib/query-key';
@@ -77,12 +78,14 @@ const connectRequest = (mapPropsToConfigs, options = {}) => WrappedComponent => 
         }
 
         cancelPendingRequests(cancelKeys) {
-            const { dispatch } = this.context.store;
-            const pendingKeys = Object.keys(this._pendingRequests);
+            setImmediate(() => {
+                const { dispatch } = this.context.store;
+                const pendingKeys = Object.keys(this._pendingRequests);
 
-            ensureArray(cancelKeys)
-                .filter(key => includes(pendingKeys, key))
-                .forEach(queryKey => dispatch(cancelQuery(queryKey)));
+                ensureArray(cancelKeys)
+                    .filter(key => includes(pendingKeys, key))
+                    .forEach(queryKey => dispatch(cancelQuery(queryKey)));
+            });
         }
 
         requestAsync(configs, force = false, retry = false) {

--- a/src/components/connect-request.js
+++ b/src/components/connect-request.js
@@ -2,10 +2,10 @@ import difference from 'lodash.difference';
 import includes from 'lodash.includes';
 import intersection from 'lodash.intersection';
 import React from 'react';
-import shallowCompare from 'react-addons-shallow-compare';
 
 import { requestAsync, cancelQuery } from '../actions';
 import { getQueryKey } from '../lib/query-key';
+import shallowEqual from '../lib/shallow-equal';
 import storeShape from '../lib/store-shape';
 
 const ensureArray = maybe => {
@@ -39,7 +39,7 @@ const connectRequest = (mapPropsToConfigs, options = {}) => WrappedComponent => 
 
         shouldComponentUpdate(nextProps, nextState) {
             if (pure) {
-                return shallowCompare(this, nextProps, nextState);
+                return !shallowEqual(this.props, nextProps) || !shallowEqual(this.state, nextState);
             } else {
                 return true;
             }

--- a/src/components/connect-request.js
+++ b/src/components/connect-request.js
@@ -6,7 +6,7 @@ import React from 'react';
 import shallowCompare from 'react-addons-shallow-compare';
 
 import { requestAsync, cancelQuery } from '../actions';
-import { reconcileQueryKey } from '../lib/query-key';
+import { getQueryKey } from '../lib/query-key';
 import storeShape from '../lib/store-shape';
 
 const ensureArray = maybe => {
@@ -14,8 +14,8 @@ const ensureArray = maybe => {
 };
 
 const diffConfigs = (prevConfigs, configs) => {
-    const prevQueryKeys = prevConfigs.map(reconcileQueryKey);
-    const queryKeys = configs.map(reconcileQueryKey);
+    const prevQueryKeys = prevConfigs.map(getQueryKey);
+    const queryKeys = configs.map(getQueryKey);
 
     const intersect = intersection(prevQueryKeys, queryKeys);
     const cancelKeys = difference(prevQueryKeys, intersect);
@@ -57,7 +57,7 @@ const connectRequest = (mapPropsToConfigs, options = {}) => WrappedComponent => 
 
             const { cancelKeys, requestKeys } = diffConfigs(prevConfigs, configs);
             const requestConfigs = configs.filter(config => {
-                return includes(requestKeys, reconcileQueryKey(config));
+                return includes(requestKeys, getQueryKey(config));
             });
 
             if (cancelKeys.length) {
@@ -113,7 +113,7 @@ const connectRequest = (mapPropsToConfigs, options = {}) => WrappedComponent => 
 
                 if (requestPromise) {
                     // Record pending request since a promise was returned
-                    const queryKey = reconcileQueryKey(config);
+                    const queryKey = getQueryKey(config);
                     this._pendingRequests[queryKey] = null;
 
                     requestPromise.then(() => {

--- a/src/constants/action-types.js
+++ b/src/constants/action-types.js
@@ -11,5 +11,4 @@ export const MUTATE_SUCCESS = '@@query/MUTATE_SUCCESS';
 export const MUTATE_FAILURE = '@@query/MUTATE_FAILURE';
 
 export const RESET = '@@query/RESET';
-export const REMOVE_ENTITIES = '@@query/REMOVE_ENTITIES';
-export const REMOVE_ENTITY = '@@query/REMOVE_ENTITY';
+export const UPDATE_ENTITIES = '@@query/UPDATE_ENTITIES';

--- a/src/index.js
+++ b/src/index.js
@@ -6,7 +6,7 @@ import * as errorSelectors from './selectors/error';
 import * as querySelectors from './selectors/query';
 
 export { default as connectRequest } from './components/connect-request';
-export { getQueryKey, reconcileQueryKey } from './lib/query-key';
+export { getQueryKey } from './lib/query-key';
 export { default as queriesReducer } from './reducers/queries';
 export { default as entitiesReducer } from './reducers/entities';
 export { default as errorsReducer } from './reducers/errors';

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,3 @@
-import * as actions from './actions';
 import * as actionTypes from './constants/action-types';
 import * as httpMethods from './constants/http-methods';
 import * as networkInterfaces from './network-interfaces';
@@ -13,4 +12,4 @@ export { default as errorsReducer } from './reducers/errors';
 export { default as queryMiddleware } from './middleware/query';
 export { default as queryMiddlewareAdvanced } from './middleware/query-advanced';
 export { cancelQuery, mutateAsync, requestAsync, updateEntities } from './actions';
-export { actions, actionTypes, errorSelectors, httpMethods, networkInterfaces, querySelectors };
+export { actionTypes, errorSelectors, httpMethods, networkInterfaces, querySelectors };

--- a/src/index.js
+++ b/src/index.js
@@ -1,9 +1,9 @@
 import * as actions from './actions';
 import * as actionTypes from './constants/action-types';
 import * as httpMethods from './constants/http-methods';
+import * as networkInterfaces from './network-interfaces';
 import * as querySelectors from './selectors/query';
 
-export { default as superagentAdapter } from './adapters/superagent';
 export { default as connectRequest } from './components/connect-request';
 export { getQueryKey, reconcileQueryKey } from './lib/query-key';
 export { default as queriesReducer } from './reducers/queries';
@@ -11,4 +11,4 @@ export { default as entitiesReducer } from './reducers/entities';
 export { default as queryMiddleware } from './middleware/query';
 export { default as queryMiddlewareAdvanced } from './middleware/query-advanced';
 export { cancelQuery, mutateAsync, requestAsync, removeEntities, removeEntity } from './actions';
-export { actions, actionTypes, httpMethods, querySelectors };
+export { actions, actionTypes, httpMethods, networkInterfaces, querySelectors };

--- a/src/index.js
+++ b/src/index.js
@@ -12,5 +12,5 @@ export { default as entitiesReducer } from './reducers/entities';
 export { default as errorsReducer } from './reducers/errors';
 export { default as queryMiddleware } from './middleware/query';
 export { default as queryMiddlewareAdvanced } from './middleware/query-advanced';
-export { cancelQuery, mutateAsync, requestAsync, removeEntities, removeEntity } from './actions';
+export { cancelQuery, mutateAsync, requestAsync, updateEntities } from './actions';
 export { actions, actionTypes, errorSelectors, httpMethods, networkInterfaces, querySelectors };

--- a/src/index.js
+++ b/src/index.js
@@ -2,13 +2,15 @@ import * as actions from './actions';
 import * as actionTypes from './constants/action-types';
 import * as httpMethods from './constants/http-methods';
 import * as networkInterfaces from './network-interfaces';
+import * as errorSelectors from './selectors/error';
 import * as querySelectors from './selectors/query';
 
 export { default as connectRequest } from './components/connect-request';
 export { getQueryKey, reconcileQueryKey } from './lib/query-key';
 export { default as queriesReducer } from './reducers/queries';
 export { default as entitiesReducer } from './reducers/entities';
+export { default as errorsReducer } from './reducers/errors';
 export { default as queryMiddleware } from './middleware/query';
 export { default as queryMiddlewareAdvanced } from './middleware/query-advanced';
 export { cancelQuery, mutateAsync, requestAsync, removeEntities, removeEntity } from './actions';
-export { actions, actionTypes, httpMethods, networkInterfaces, querySelectors };
+export { actions, actionTypes, errorSelectors, httpMethods, networkInterfaces, querySelectors };

--- a/src/lib/query-key.js
+++ b/src/lib/query-key.js
@@ -1,13 +1,9 @@
 import stringify from 'json-stable-stringify';
 
-export const getQueryKey = (url, body) => {
-    return stringify({ url, body });
-};
-
-export const reconcileQueryKey = ({ url, body, queryKey }) => {
+export const getQueryKey = ({ url, body, queryKey }) => {
     if (queryKey !== null && queryKey !== undefined) {
         return queryKey;
     } else {
-        return getQueryKey(url, body);
+        return stringify({ url, body });
     }
 };

--- a/src/lib/shallow-equal.js
+++ b/src/lib/shallow-equal.js
@@ -1,0 +1,42 @@
+/**
+ * This module is a modified copy from react-redux (MIT).
+ */
+
+const hasOwn = Object.prototype.hasOwnProperty;
+
+const is = (x, y) => {
+    if (x === y) {
+        return x !== 0 || y !== 0 || 1 / x === 1 / y;
+    } else {
+        /* eslint-disable no-self-compare */
+        return x !== x && y !== y;
+        /* eslint-enable no-self-compare */
+    }
+};
+
+const shallowEqual = (objA, objB) => {
+    if (is(objA, objB)) {
+        return true;
+    }
+
+    if (typeof objA !== 'object' || objA === null || typeof objB !== 'object' || objB === null) {
+        return false;
+    }
+
+    const keysA = Object.keys(objA);
+    const keysB = Object.keys(objB);
+
+    if (keysA.length !== keysB.length) {
+        return false;
+    }
+
+    for (let i = 0; i < keysA.length; i++) {
+        if (!hasOwn.call(objB, keysA[i]) || !is(objA[keysA[i]], objB[keysA[i]])) {
+            return false;
+        }
+    }
+
+    return true;
+};
+
+export default shallowEqual;

--- a/src/lib/update.js
+++ b/src/lib/update.js
@@ -1,40 +1,31 @@
 export const updateEntities = (update, entities, transformed) => {
     // If update is not supplied, then no change to entities will be made
 
-    return Object.keys(update || {}).reduce(
-        (accum, key) => {
-            accum[key] = update[key]((entities || {})[key], (transformed || {})[key]);
+    return Object.keys(update || {}).reduce((accum, key) => {
+        accum[key] = update[key]((entities || {})[key], (transformed || {})[key]);
 
-            return accum;
-        },
-        {}
-    );
+        return accum;
+    }, {});
 };
 
 export const optimisticUpdateEntities = (optimisticUpdate, entities) => {
-    return Object.keys(optimisticUpdate).reduce(
-        (accum, key) => {
-            accum[key] = optimisticUpdate[key](entities[key]);
+    return Object.keys(optimisticUpdate).reduce((accum, key) => {
+        accum[key] = optimisticUpdate[key](entities[key]);
 
-            return accum;
-        },
-        {}
-    );
+        return accum;
+    }, {});
 };
 
 export const rollbackEntities = (rollback = {}, initialEntities, entities) => {
-    return Object.keys(initialEntities).reduce(
-        (accum, key) => {
-            if (rollback[key]) {
-                accum[key] = rollback[key](initialEntities[key], entities[key]);
-            } else {
-                // Default to just reverting to the initial state for that
-                // entity (before the optimistic update)
-                accum[key] = initialEntities[key];
-            }
+    return Object.keys(initialEntities).reduce((accum, key) => {
+        if (rollback[key]) {
+            accum[key] = rollback[key](initialEntities[key], entities[key]);
+        } else {
+            // Default to just reverting to the initial state for that
+            // entity (before the optimistic update)
+            accum[key] = initialEntities[key];
+        }
 
-            return accum;
-        },
-        {}
-    );
+        return accum;
+    }, {});
 };

--- a/src/lib/update.js
+++ b/src/lib/update.js
@@ -14,11 +14,7 @@ export const updateEntities = (update, entities, transformed) => {
 export const optimisticUpdateEntities = (optimisticUpdate, entities) => {
     return Object.keys(optimisticUpdate).reduce(
         (accum, key) => {
-            if (optimisticUpdate[key]) {
-                accum[key] = optimisticUpdate[key](entities[key]);
-            } else {
-                accum[key] = entities[key];
-            }
+            accum[key] = optimisticUpdate[key](entities[key]);
 
             return accum;
         },

--- a/src/lib/update.js
+++ b/src/lib/update.js
@@ -1,0 +1,44 @@
+export const updateEntities = (update, entities, transformed) => {
+    // If update is not supplied, then no change to entities will be made
+
+    return Object.keys(update || {}).reduce(
+        (accum, key) => {
+            accum[key] = update[key]((entities || {})[key], (transformed || {})[key]);
+
+            return accum;
+        },
+        {}
+    );
+};
+
+export const optimisticUpdateEntities = (optimisticUpdate, entities) => {
+    return Object.keys(optimisticUpdate).reduce(
+        (accum, key) => {
+            if (optimisticUpdate[key]) {
+                accum[key] = optimisticUpdate[key](entities[key]);
+            } else {
+                accum[key] = entities[key];
+            }
+
+            return accum;
+        },
+        {}
+    );
+};
+
+export const rollbackEntities = (rollback = {}, initialEntities, entities) => {
+    return Object.keys(initialEntities).reduce(
+        (accum, key) => {
+            if (rollback[key]) {
+                accum[key] = rollback[key](initialEntities[key], entities[key]);
+            } else {
+                // Default to just reverting to the initial state for that
+                // entity (before the optimistic update)
+                accum[key] = initialEntities[key];
+            }
+
+            return accum;
+        },
+        {}
+    );
+};

--- a/src/middleware/query-advanced.js
+++ b/src/middleware/query-advanced.js
@@ -282,7 +282,6 @@ const queryMiddlewareAdvanced = networkInterface => (queriesSelector, entitiesSe
                                 duration,
                                 status: resStatus,
                                 text: resText,
-                                rolledBackEntities,
                                 headers: resHeaders,
                             });
                         } else {

--- a/src/middleware/query-advanced.js
+++ b/src/middleware/query-advanced.js
@@ -109,6 +109,10 @@ const queryMiddlewareAdvanced = networkInterface => (queriesSelector, entitiesSe
                                 let transformed;
                                 let newEntities;
 
+                                if (action.unstable_preDispatchCallback) {
+                                    action.unstable_preDispatchCallback();
+                                }
+
                                 if (err || !resOk(status)) {
                                     dispatch(
                                         requestFailure({

--- a/src/middleware/query-advanced.js
+++ b/src/middleware/query-advanced.js
@@ -141,10 +141,22 @@ const queryMiddlewareAdvanced = networkAdapter => (queriesSelector, entitiesSele
                                     return;
                                 }
 
+                                const end = new Date();
+                                const duration = end - start;
                                 let transformed;
                                 let newEntities;
 
                                 if (err || !resOk(resStatus)) {
+                                    resolve({
+                                        body: resBody,
+                                        duration,
+                                        status: resStatus,
+                                        text: resText,
+                                        transformed,
+                                        entities: newEntities,
+                                        headers: resHeaders,
+                                    });
+
                                     dispatch(
                                         requestFailure(
                                             url,
@@ -162,6 +174,17 @@ const queryMiddlewareAdvanced = networkAdapter => (queriesSelector, entitiesSele
                                     const entities = entitiesSelector(callbackState);
                                     transformed = transform(resBody, resText);
                                     newEntities = updateEntities(update, entities, transformed);
+
+                                    resolve({
+                                        body: resBody,
+                                        duration,
+                                        status: resStatus,
+                                        text: resText,
+                                        transformed,
+                                        entities: newEntities,
+                                        headers: resHeaders,
+                                    });
+
                                     dispatch(
                                         requestSuccess(
                                             url,
@@ -176,18 +199,6 @@ const queryMiddlewareAdvanced = networkAdapter => (queriesSelector, entitiesSele
                                         )
                                     );
                                 }
-
-                                const end = new Date();
-                                const duration = end - start;
-                                resolve({
-                                    body: resBody,
-                                    duration,
-                                    status: resStatus,
-                                    text: resText,
-                                    transformed,
-                                    entities: newEntities,
-                                    headers: resHeaders,
-                                });
                             });
                         };
 
@@ -235,6 +246,8 @@ const queryMiddlewareAdvanced = networkAdapter => (queriesSelector, entitiesSele
                     dispatch(mutateStart(url, body, request, optimisticEntities, queryKey, meta));
 
                     request.execute((err, resStatus, resBody, resText, resHeaders) => {
+                        const end = new Date();
+                        const duration = end - start;
                         const state = getState();
                         const entities = entitiesSelector(state);
                         let transformed;
@@ -256,6 +269,16 @@ const queryMiddlewareAdvanced = networkAdapter => (queriesSelector, entitiesSele
                                 newEntities = entities;
                             }
 
+                            resolve({
+                                body: resBody,
+                                duration,
+                                status: resStatus,
+                                text: resText,
+                                transformed,
+                                entities: newEntities,
+                                headers: resHeaders,
+                            });
+
                             dispatch(
                                 mutateFailure(
                                     url,
@@ -274,6 +297,16 @@ const queryMiddlewareAdvanced = networkAdapter => (queriesSelector, entitiesSele
                             transformed = transform(resBody, resText);
                             newEntities = updateEntities(update, entities, transformed);
 
+                            resolve({
+                                body: resBody,
+                                duration,
+                                status: resStatus,
+                                text: resText,
+                                transformed,
+                                entities: newEntities,
+                                headers: resHeaders,
+                            });
+
                             dispatch(
                                 mutateSuccess(
                                     url,
@@ -288,18 +321,6 @@ const queryMiddlewareAdvanced = networkAdapter => (queriesSelector, entitiesSele
                                 )
                             );
                         }
-
-                        const end = new Date();
-                        const duration = end - start;
-                        resolve({
-                            body: resBody,
-                            duration,
-                            status: resStatus,
-                            text: resText,
-                            transformed,
-                            entities: newEntities,
-                            headers: resHeaders,
-                        });
                     });
                 });
 

--- a/src/middleware/query-advanced.js
+++ b/src/middleware/query-advanced.js
@@ -11,51 +11,7 @@ import * as actionTypes from '../constants/action-types';
 import * as httpMethods from '../constants/http-methods';
 import * as statusCodes from '../constants/status-codes';
 import { reconcileQueryKey } from '../lib/query-key';
-
-const updateEntities = (update, entities, transformed) => {
-    // If update, not supplied, then no change to entities should be made
-
-    return Object.keys(update || {}).reduce(
-        (accum, key) => {
-            accum[key] = update[key]((entities || {})[key], (transformed || {})[key]);
-
-            return accum;
-        },
-        {}
-    );
-};
-
-const optimisticUpdateEntities = (optimisticUpdate, entities) => {
-    return Object.keys(optimisticUpdate).reduce(
-        (accum, key) => {
-            if (optimisticUpdate[key]) {
-                accum[key] = optimisticUpdate[key](entities[key]);
-            } else {
-                accum[key] = entities[key];
-            }
-
-            return accum;
-        },
-        {}
-    );
-};
-
-const rollbackEntities = (rollback = {}, initialEntities, entities) => {
-    return Object.keys(initialEntities).reduce(
-        (accum, key) => {
-            if (rollback[key]) {
-                accum[key] = rollback[key](initialEntities[key], entities[key]);
-            } else {
-                // Default to just reverting to the initial state for that
-                // entity (before the optimistic update)
-                accum[key] = initialEntities[key];
-            }
-
-            return accum;
-        },
-        {}
-    );
-};
+import { updateEntities, optimisticUpdateEntities, rollbackEntities } from '../lib/update';
 
 const defaultConfig = {
     backoff: {

--- a/src/middleware/query-advanced.js
+++ b/src/middleware/query-advanced.js
@@ -36,7 +36,6 @@ const resOk = status => Math.floor(status / 100) === 2;
 
 const queryMiddlewareAdvanced = networkInterface => (queriesSelector, entitiesSelector, config = defaultConfig) => {
     return ({ dispatch, getState }) => next => action => {
-        // TODO(ryan): add warnings when there are simultaneous requests and mutation queries for the same entities
         let returnValue;
 
         switch (action.type) {

--- a/src/middleware/query-advanced.js
+++ b/src/middleware/query-advanced.js
@@ -40,16 +40,7 @@ const queryMiddlewareAdvanced = networkInterface => (queriesSelector, entitiesSe
 
         switch (action.type) {
             case actionTypes.REQUEST_ASYNC: {
-                const {
-                    url,
-                    body,
-                    force,
-                    retry,
-                    transform = identity,
-                    update,
-                    options = {},
-                    meta,
-                } = action;
+                const { url, body, force, retry, transform = identity, update, options = {}, meta } = action;
 
                 invariant(!!url, 'Missing required `url` field in action handler');
                 invariant(!!update, 'Missing required `update` field in action handler');

--- a/src/middleware/query-advanced.js
+++ b/src/middleware/query-advanced.js
@@ -68,13 +68,6 @@ const queryMiddlewareAdvanced = networkInterface => (queriesSelector, entitiesSe
                     returnValue = new Promise(resolve => {
                         const start = new Date();
                         const { method = httpMethods.GET } = options;
-
-                        const networkHandler = networkInterface(url, method, {
-                            body,
-                            headers: options.headers,
-                            credentials: options.credentials,
-                        });
-
                         let attempts = 0;
                         const backoff = new Backoff({
                             min: config.backoff.minDuration,
@@ -82,6 +75,12 @@ const queryMiddlewareAdvanced = networkInterface => (queriesSelector, entitiesSe
                         });
 
                         const attemptRequest = () => {
+                            const networkHandler = networkInterface(url, method, {
+                                body,
+                                headers: options.headers,
+                                credentials: options.credentials,
+                            });
+
                             dispatch(
                                 requestStart({
                                     body,

--- a/src/middleware/query-advanced.js
+++ b/src/middleware/query-advanced.js
@@ -152,8 +152,6 @@ const queryMiddlewareAdvanced = networkAdapter => (queriesSelector, entitiesSele
                                         duration,
                                         status: resStatus,
                                         text: resText,
-                                        transformed,
-                                        entities: newEntities,
                                         headers: resHeaders,
                                     });
 
@@ -254,19 +252,14 @@ const queryMiddlewareAdvanced = networkAdapter => (queriesSelector, entitiesSele
                         let newEntities;
 
                         if (err || !resOk(resStatus)) {
+                            let rolledBackEntities;
+
                             if (optimisticUpdate) {
-                                const rolledBackEntities = rollbackEntities(
+                                rolledBackEntities = rollbackEntities(
                                     rollback,
                                     pick(initialEntities, Object.keys(optimisticEntities)),
                                     pick(entities, Object.keys(optimisticEntities))
                                 );
-
-                                newEntities = {
-                                    ...entities,
-                                    ...rolledBackEntities,
-                                };
-                            } else {
-                                newEntities = entities;
                             }
 
                             resolve({
@@ -274,8 +267,7 @@ const queryMiddlewareAdvanced = networkAdapter => (queriesSelector, entitiesSele
                                 duration,
                                 status: resStatus,
                                 text: resText,
-                                transformed,
-                                entities: newEntities,
+                                rolledBackEntities,
                                 headers: resHeaders,
                             });
 
@@ -290,7 +282,7 @@ const queryMiddlewareAdvanced = networkAdapter => (queriesSelector, entitiesSele
                                     resText,
                                     resHeaders,
                                     meta,
-                                    newEntities
+                                    rolledBackEntities
                                 )
                             );
                         } else {

--- a/src/middleware/query-advanced.js
+++ b/src/middleware/query-advanced.js
@@ -109,7 +109,7 @@ const queryMiddlewareAdvanced = networkAdapter => (queriesSelector, entitiesSele
                         });
 
                         const attemptRequest = () => {
-                            dispatch(requestStart(url, body, request.instance, meta, queryKey));
+                            dispatch(requestStart(url, body, request, meta, queryKey));
 
                             attempts += 1;
 
@@ -212,7 +212,7 @@ const queryMiddlewareAdvanced = networkAdapter => (queriesSelector, entitiesSele
 
                     // Note: only the entities that are included in `optimisticUpdate` will be passed along in the
                     // `mutateStart` action as `optimisticEntities`
-                    dispatch(mutateStart(url, body, request.instance, optimisticEntities, queryKey, meta));
+                    dispatch(mutateStart(url, body, request, optimisticEntities, queryKey, meta));
 
                     request.execute((err, resStatus, resBody, resText, resHeaders) => {
                         let transformed;

--- a/src/middleware/query-advanced.js
+++ b/src/middleware/query-advanced.js
@@ -10,7 +10,7 @@ import { requestStart, requestFailure, requestSuccess, mutateStart, mutateFailur
 import * as actionTypes from '../constants/action-types';
 import * as httpMethods from '../constants/http-methods';
 import * as statusCodes from '../constants/status-codes';
-import { reconcileQueryKey } from '../lib/query-key';
+import { getQueryKey } from '../lib/query-key';
 import { updateEntities, optimisticUpdateEntities, rollbackEntities } from '../lib/update';
 
 const defaultConfig = {
@@ -55,7 +55,7 @@ const queryMiddlewareAdvanced = networkInterface => (queriesSelector, entitiesSe
                 invariant(!!url, 'Missing required `url` field in action handler');
                 invariant(!!update, 'Missing required `update` field in action handler');
 
-                const queryKey = reconcileQueryKey(action);
+                const queryKey = getQueryKey(action);
 
                 const state = getState();
                 const queries = queriesSelector(state);
@@ -191,7 +191,7 @@ const queryMiddlewareAdvanced = networkInterface => (queriesSelector, entitiesSe
                     optimisticEntities = optimisticUpdateEntities(optimisticUpdate, initialEntities);
                 }
 
-                const queryKey = reconcileQueryKey(action);
+                const queryKey = getQueryKey(action);
 
                 returnValue = new Promise(resolve => {
                     const start = new Date();

--- a/src/middleware/query-advanced.js
+++ b/src/middleware/query-advanced.js
@@ -267,13 +267,12 @@ const queryMiddlewareAdvanced = networkInterface => (queriesSelector, entitiesSe
                                     url,
                                     body,
                                     resStatus,
-                                    initialEntities,
+                                    rolledBackEntities,
                                     queryKey,
                                     resBody,
                                     resText,
                                     resHeaders,
-                                    meta,
-                                    rolledBackEntities
+                                    meta
                                 )
                             );
 

--- a/src/middleware/query-advanced.js
+++ b/src/middleware/query-advanced.js
@@ -41,7 +41,7 @@ const optimisticUpdateEntities = (optimisticUpdate, entities) => {
 };
 
 const rollbackEntities = (rollback = {}, initialEntities, entities) => {
-    return Object.keys(rollback).reduce(
+    return Object.keys(initialEntities).reduce(
         (accum, key) => {
             if (rollback[key]) {
                 accum[key] = rollback[key](initialEntities[key], entities[key]);

--- a/src/middleware/query-advanced.js
+++ b/src/middleware/query-advanced.js
@@ -147,14 +147,6 @@ const queryMiddlewareAdvanced = networkAdapter => (queriesSelector, entitiesSele
                                 let newEntities;
 
                                 if (err || !resOk(resStatus)) {
-                                    resolve({
-                                        body: resBody,
-                                        duration,
-                                        status: resStatus,
-                                        text: resText,
-                                        headers: resHeaders,
-                                    });
-
                                     dispatch(
                                         requestFailure(
                                             url,
@@ -167,21 +159,19 @@ const queryMiddlewareAdvanced = networkAdapter => (queriesSelector, entitiesSele
                                             resHeaders
                                         )
                                     );
-                                } else {
-                                    const callbackState = getState();
-                                    const entities = entitiesSelector(callbackState);
-                                    transformed = transform(resBody, resText);
-                                    newEntities = updateEntities(update, entities, transformed);
 
                                     resolve({
                                         body: resBody,
                                         duration,
                                         status: resStatus,
                                         text: resText,
-                                        transformed,
-                                        entities: newEntities,
                                         headers: resHeaders,
                                     });
+                                } else {
+                                    const callbackState = getState();
+                                    const entities = entitiesSelector(callbackState);
+                                    transformed = transform(resBody, resText);
+                                    newEntities = updateEntities(update, entities, transformed);
 
                                     dispatch(
                                         requestSuccess(
@@ -196,6 +186,16 @@ const queryMiddlewareAdvanced = networkAdapter => (queriesSelector, entitiesSele
                                             resHeaders
                                         )
                                     );
+
+                                    resolve({
+                                        body: resBody,
+                                        duration,
+                                        status: resStatus,
+                                        text: resText,
+                                        transformed,
+                                        entities: newEntities,
+                                        headers: resHeaders,
+                                    });
                                 }
                             });
                         };
@@ -262,15 +262,6 @@ const queryMiddlewareAdvanced = networkAdapter => (queriesSelector, entitiesSele
                                 );
                             }
 
-                            resolve({
-                                body: resBody,
-                                duration,
-                                status: resStatus,
-                                text: resText,
-                                rolledBackEntities,
-                                headers: resHeaders,
-                            });
-
                             dispatch(
                                 mutateFailure(
                                     url,
@@ -285,19 +276,18 @@ const queryMiddlewareAdvanced = networkAdapter => (queriesSelector, entitiesSele
                                     rolledBackEntities
                                 )
                             );
-                        } else {
-                            transformed = transform(resBody, resText);
-                            newEntities = updateEntities(update, entities, transformed);
 
                             resolve({
                                 body: resBody,
                                 duration,
                                 status: resStatus,
                                 text: resText,
-                                transformed,
-                                entities: newEntities,
+                                rolledBackEntities,
                                 headers: resHeaders,
                             });
+                        } else {
+                            transformed = transform(resBody, resText);
+                            newEntities = updateEntities(update, entities, transformed);
 
                             dispatch(
                                 mutateSuccess(
@@ -312,6 +302,16 @@ const queryMiddlewareAdvanced = networkAdapter => (queriesSelector, entitiesSele
                                     meta
                                 )
                             );
+
+                            resolve({
+                                body: resBody,
+                                duration,
+                                status: resStatus,
+                                text: resText,
+                                transformed,
+                                entities: newEntities,
+                                headers: resHeaders,
+                            });
                         }
                     });
                 });

--- a/src/middleware/query.js
+++ b/src/middleware/query.js
@@ -1,6 +1,6 @@
 import queryAdvanced from './query-advanced.js';
-import superagentAdapter from '../adapters/superagent';
+import superagentInterface from '../network-interfaces/superagent';
 
-const queryMiddleware = queryAdvanced(superagentAdapter);
+const queryMiddleware = queryAdvanced(superagentInterface);
 
 export default queryMiddleware;

--- a/src/network-interfaces/index.js
+++ b/src/network-interfaces/index.js
@@ -1,0 +1,1 @@
+export { default as superagent } from './superagent';

--- a/src/network-interfaces/superagent.js
+++ b/src/network-interfaces/superagent.js
@@ -31,14 +31,15 @@ const superagentNetworkInterface = (url, method, { body, headers, credentials } 
         request.withCredentials();
     }
 
-    const execute = cb => request.end((err, response) => {
-        const resStatus = (response && response.status) || 0;
-        const resBody = (response && response.body) || undefined;
-        const resText = (response && response.text) || undefined;
-        const resHeaders = (response && response.header) || undefined;
+    const execute = cb =>
+        request.end((err, response) => {
+            const resStatus = (response && response.status) || 0;
+            const resBody = (response && response.body) || undefined;
+            const resText = (response && response.text) || undefined;
+            const resHeaders = (response && response.header) || undefined;
 
-        cb(err, resStatus, resBody, resText, resHeaders);
-    });
+            cb(err, resStatus, resBody, resText, resHeaders);
+        });
 
     const abort = () => request.abort();
 

--- a/src/network-interfaces/superagent.js
+++ b/src/network-interfaces/superagent.js
@@ -20,7 +20,7 @@ const createRequest = (url, method, body) => {
     }
 };
 
-const superagentNetworkAdapter = (url, method, { body, headers, credentials } = {}) => {
+const superagentNetworkInterface = (url, method, { body, headers, credentials } = {}) => {
     const request = createRequest(url, method, body);
 
     if (headers) {
@@ -49,4 +49,4 @@ const superagentNetworkAdapter = (url, method, { body, headers, credentials } = 
     };
 };
 
-export default superagentNetworkAdapter;
+export default superagentNetworkInterface;

--- a/src/network-interfaces/superagent.js
+++ b/src/network-interfaces/superagent.js
@@ -14,7 +14,7 @@ const createRequest = (url, method, body) => {
         case httpMethods.PATCH:
             return superagent.patch(url, body);
         case httpMethods.DELETE:
-            return superagent.del(url, body);
+            return superagent.delete(url, body);
         default:
             throw new Error(`Unsupported HTTP method: ${method}`);
     }

--- a/src/reducers/entities.js
+++ b/src/reducers/entities.js
@@ -6,9 +6,9 @@ import {
     MUTATE_SUCCESS,
     REQUEST_SUCCESS,
     RESET,
-    REMOVE_ENTITIES,
-    REMOVE_ENTITY,
+    UPDATE_ENTITIES,
 } from '../constants/action-types';
+import { optimisticUpdateEntities } from '../lib/update';
 
 const initialState = {};
 
@@ -43,15 +43,11 @@ const entities = (state = initialState, action) => {
             ...state,
             ...action.entities,
         };
-    } else if (action.type === REMOVE_ENTITIES) {
-        return action.paths.reduce(
-            (accum, path) => {
-                return withoutPath(accum, path);
-            },
-            state
-        );
-    } else if (action.type === REMOVE_ENTITY) {
-        return withoutPath(state, action.path);
+    } else if (action.type === UPDATE_ENTITIES) {
+        return {
+            ...state,
+            ...optimisticUpdateEntities(action.update, state),
+        };
     } else {
         return state;
     }

--- a/src/reducers/entities.js
+++ b/src/reducers/entities.js
@@ -33,10 +33,10 @@ const entities = (state = initialState, action) => {
             ...state,
             ...action.optimisticEntities,
         };
-    } else if (action.type === MUTATE_FAILURE && action.originalEntities) {
+    } else if (action.type === MUTATE_FAILURE && action.entities) {
         return {
             ...state,
-            ...action.originalEntities,
+            ...action.entities,
         };
     } else if (action.type === REQUEST_SUCCESS || action.type === MUTATE_SUCCESS) {
         return {

--- a/src/reducers/entities.js
+++ b/src/reducers/entities.js
@@ -33,10 +33,10 @@ const entities = (state = initialState, action) => {
             ...state,
             ...action.optimisticEntities,
         };
-    } else if (action.type === MUTATE_FAILURE && action.entities) {
+    } else if (action.type === MUTATE_FAILURE && action.rolledBackEntities) {
         return {
             ...state,
-            ...action.entities,
+            ...action.rolledBackEntities,
         };
     } else if (action.type === REQUEST_SUCCESS || action.type === MUTATE_SUCCESS) {
         return {

--- a/src/reducers/errors.js
+++ b/src/reducers/errors.js
@@ -1,0 +1,38 @@
+import omit from 'lodash.omit';
+
+import * as actionTypes from '../constants/action-types';
+
+const initialState = {};
+
+const queries = (state = initialState, action) => {
+    switch (action.type) {
+        case actionTypes.RESET: {
+            return {};
+        }
+        case actionTypes.MUTATE_START:
+        case actionTypes.REQUEST_START: {
+            const { queryKey } = action;
+
+            return omit(state, queryKey);
+        }
+        case actionTypes.MUTATE_FAILURE:
+        case actionTypes.REQUEST_FAILURE: {
+            const { queryKey } = action;
+
+            return {
+                ...state,
+                [queryKey]: {
+                    ...state[queryKey],
+                    responseBody: action.responseBody,
+                    responseText: action.responseText,
+                    responseHeaders: action.responseHeaders,
+                },
+            };
+        }
+        default: {
+            return state;
+        }
+    }
+};
+
+export default queries;

--- a/src/reducers/queries.js
+++ b/src/reducers/queries.js
@@ -17,7 +17,7 @@ const queries = (state = initialState, action) => {
                     url: action.url,
                     isFinished: false,
                     isPending: true,
-                    request: action.request,
+                    networkHandler: action.networkHandler,
                     isMutation: action.type === actionTypes.MUTATE_START,
                     queryCount: state[queryKey] ? state[queryKey].queryCount + 1 : 1,
                 },
@@ -44,7 +44,7 @@ const queries = (state = initialState, action) => {
             const { queryKey } = action;
 
             if (state[queryKey].isPending) {
-                // Make sure request is actually pending
+                // Make sure query is actually pending
 
                 return {
                     ...state,

--- a/src/selectors/error.js
+++ b/src/selectors/error.js
@@ -1,0 +1,39 @@
+import get from 'lodash.get';
+
+import { reconcileQueryKey } from '../lib/query-key';
+
+export const responseBody = (urlOrConfig, body) => errorsState => {
+    let queryKey;
+
+    if (typeof urlOrConfig === 'string') {
+        queryKey = reconcileQueryKey({ url: urlOrConfig, body });
+    } else {
+        queryKey = reconcileQueryKey(urlOrConfig);
+    }
+
+    return get(errorsState, [queryKey, 'responseBody']);
+};
+
+export const responseText = (urlOrConfig, body) => errorsState => {
+    let queryKey;
+
+    if (typeof urlOrConfig === 'string') {
+        queryKey = reconcileQueryKey({ url: urlOrConfig, body });
+    } else {
+        queryKey = reconcileQueryKey(urlOrConfig);
+    }
+
+    return get(errorsState, [queryKey, 'responseText']);
+};
+
+export const responseHeaders = (urlOrConfig, body) => errorsState => {
+    let queryKey;
+
+    if (typeof urlOrConfig === 'string') {
+        queryKey = reconcileQueryKey({ url: urlOrConfig, body });
+    } else {
+        queryKey = reconcileQueryKey(urlOrConfig);
+    }
+
+    return get(errorsState, [queryKey, 'responseHeaders']);
+};

--- a/src/selectors/error.js
+++ b/src/selectors/error.js
@@ -1,39 +1,21 @@
 import get from 'lodash.get';
 
-import { reconcileQueryKey } from '../lib/query-key';
+import { getQueryKey } from '../lib/query-key';
 
-export const responseBody = (urlOrConfig, body) => errorsState => {
-    let queryKey;
-
-    if (typeof urlOrConfig === 'string') {
-        queryKey = reconcileQueryKey({ url: urlOrConfig, body });
-    } else {
-        queryKey = reconcileQueryKey(urlOrConfig);
-    }
+export const responseBody = (errorsState, queryConfig) => {
+    const queryKey = getQueryKey(queryConfig);
 
     return get(errorsState, [queryKey, 'responseBody']);
 };
 
-export const responseText = (urlOrConfig, body) => errorsState => {
-    let queryKey;
-
-    if (typeof urlOrConfig === 'string') {
-        queryKey = reconcileQueryKey({ url: urlOrConfig, body });
-    } else {
-        queryKey = reconcileQueryKey(urlOrConfig);
-    }
+export const responseText = (errorsState, queryConfig) => {
+    const queryKey = getQueryKey(queryConfig);
 
     return get(errorsState, [queryKey, 'responseText']);
 };
 
-export const responseHeaders = (urlOrConfig, body) => errorsState => {
-    let queryKey;
-
-    if (typeof urlOrConfig === 'string') {
-        queryKey = reconcileQueryKey({ url: urlOrConfig, body });
-    } else {
-        queryKey = reconcileQueryKey(urlOrConfig);
-    }
+export const responseHeaders = (errorsState, queryConfig) => {
+    const queryKey = getQueryKey(queryConfig);
 
     return get(errorsState, [queryKey, 'responseHeaders']);
 };

--- a/src/selectors/error.js
+++ b/src/selectors/error.js
@@ -3,19 +3,25 @@ import get from 'lodash.get';
 import { getQueryKey } from '../lib/query-key';
 
 export const responseBody = (errorsState, queryConfig) => {
-    const queryKey = getQueryKey(queryConfig);
+    if (queryConfig) {
+        const queryKey = getQueryKey(queryConfig);
 
-    return get(errorsState, [queryKey, 'responseBody']);
+        return get(errorsState, [queryKey, 'responseBody']);
+    }
 };
 
 export const responseText = (errorsState, queryConfig) => {
-    const queryKey = getQueryKey(queryConfig);
+    if (queryConfig) {
+        const queryKey = getQueryKey(queryConfig);
 
-    return get(errorsState, [queryKey, 'responseText']);
+        return get(errorsState, [queryKey, 'responseText']);
+    }
 };
 
 export const responseHeaders = (errorsState, queryConfig) => {
-    const queryKey = getQueryKey(queryConfig);
+    if (queryConfig) {
+        const queryKey = getQueryKey(queryConfig);
 
-    return get(errorsState, [queryKey, 'responseHeaders']);
+        return get(errorsState, [queryKey, 'responseHeaders']);
+    }
 };

--- a/src/selectors/query.js
+++ b/src/selectors/query.js
@@ -3,31 +3,41 @@ import get from 'lodash.get';
 import { getQueryKey } from '../lib/query-key';
 
 export const isFinished = (queriesState, queryConfig) => {
-    const queryKey = getQueryKey(queryConfig);
+    if (queryConfig) {
+        const queryKey = getQueryKey(queryConfig);
 
-    return get(queriesState, [queryKey, 'isFinished']);
+        return get(queriesState, [queryKey, 'isFinished']);
+    }
 };
 
 export const isPending = (queriesState, queryConfig) => {
-    const queryKey = getQueryKey(queryConfig);
+    if (queryConfig) {
+        const queryKey = getQueryKey(queryConfig);
 
-    return get(queriesState, [queryKey, 'isPending']);
+        return get(queriesState, [queryKey, 'isPending']);
+    }
 };
 
 export const status = (queriesState, queryConfig) => {
-    const queryKey = getQueryKey(queryConfig);
+    if (queryConfig) {
+        const queryKey = getQueryKey(queryConfig);
 
-    return get(queriesState, [queryKey, 'status']);
+        return get(queriesState, [queryKey, 'status']);
+    }
 };
 
 export const lastUpdated = (queriesState, queryConfig) => {
-    const queryKey = getQueryKey(queryConfig);
+    if (queryConfig) {
+        const queryKey = getQueryKey(queryConfig);
 
-    return get(queriesState, [queryKey, 'lastUpdated']);
+        return get(queriesState, [queryKey, 'lastUpdated']);
+    }
 };
 
 export const queryCount = (queriesState, queryConfig) => {
-    const queryKey = getQueryKey(queryConfig);
+    if (queryConfig) {
+        const queryKey = getQueryKey(queryConfig);
 
-    return get(queriesState, [queryKey, 'queryCount']);
+        return get(queriesState, [queryKey, 'queryCount']);
+    }
 };

--- a/src/selectors/query.js
+++ b/src/selectors/query.js
@@ -1,63 +1,33 @@
 import get from 'lodash.get';
 
-import { reconcileQueryKey } from '../lib/query-key';
+import { getQueryKey } from '../lib/query-key';
 
-export const isFinished = (urlOrConfig, body) => queriesState => {
-    let queryKey;
-
-    if (typeof urlOrConfig === 'string') {
-        queryKey = reconcileQueryKey({ url: urlOrConfig, body });
-    } else {
-        queryKey = reconcileQueryKey(urlOrConfig);
-    }
+export const isFinished = (queriesState, queryConfig) => {
+    const queryKey = getQueryKey(queryConfig);
 
     return get(queriesState, [queryKey, 'isFinished']);
 };
 
-export const isPending = (urlOrConfig, body) => queriesState => {
-    let queryKey;
-
-    if (typeof urlOrConfig === 'string') {
-        queryKey = reconcileQueryKey({ url: urlOrConfig, body });
-    } else {
-        queryKey = reconcileQueryKey(urlOrConfig);
-    }
+export const isPending = (queriesState, queryConfig) => {
+    const queryKey = getQueryKey(queryConfig);
 
     return get(queriesState, [queryKey, 'isPending']);
 };
 
-export const status = (urlOrConfig, body) => queriesState => {
-    let queryKey;
-
-    if (typeof urlOrConfig === 'string') {
-        queryKey = reconcileQueryKey({ url: urlOrConfig, body });
-    } else {
-        queryKey = reconcileQueryKey(urlOrConfig);
-    }
+export const status = (queriesState, queryConfig) => {
+    const queryKey = getQueryKey(queryConfig);
 
     return get(queriesState, [queryKey, 'status']);
 };
 
-export const lastUpdated = (urlOrConfig, body) => queriesState => {
-    let queryKey;
-
-    if (typeof urlOrConfig === 'string') {
-        queryKey = reconcileQueryKey({ url: urlOrConfig, body });
-    } else {
-        queryKey = reconcileQueryKey(urlOrConfig);
-    }
+export const lastUpdated = (queriesState, queryConfig) => {
+    const queryKey = getQueryKey(queryConfig);
 
     return get(queriesState, [queryKey, 'lastUpdated']);
 };
 
-export const queryCount = (urlOrConfig, body) => queriesState => {
-    let queryKey;
-
-    if (typeof urlOrConfig === 'string') {
-        queryKey = reconcileQueryKey({ url: urlOrConfig, body });
-    } else {
-        queryKey = reconcileQueryKey(urlOrConfig);
-    }
+export const queryCount = (queriesState, queryConfig) => {
+    const queryKey = getQueryKey(queryConfig);
 
     return get(queriesState, [queryKey, 'queryCount']);
 };

--- a/test/middlewares/query.test.js
+++ b/test/middlewares/query.test.js
@@ -552,9 +552,6 @@ describe('query middleware', () => {
                     type: actionTypes.MUTATE_FAILURE,
                     url,
                     status: 404,
-                    originalEntities: {
-                        message: apiMessage,
-                    },
                     rolledBackEntities: {
                         message: apiMessage,
                     },
@@ -600,11 +597,6 @@ describe('query middleware', () => {
                     type: actionTypes.MUTATE_FAILURE,
                     url,
                     status: 404,
-                    originalEntities: {
-                        messagesById: {
-                            hello: null,
-                        },
-                    },
                     rolledBackEntities: {
                         messagesById: {
                             hello: null,

--- a/test/middlewares/query.test.js
+++ b/test/middlewares/query.test.js
@@ -555,7 +555,7 @@ describe('query middleware', () => {
                     originalEntities: {
                         message: apiMessage,
                     },
-                    entities: {
+                    rolledBackEntities: {
                         message: apiMessage,
                     },
                 },
@@ -605,7 +605,7 @@ describe('query middleware', () => {
                             hello: null,
                         },
                     },
-                    entities: {
+                    rolledBackEntities: {
                         messagesById: {
                             hello: null,
                         },

--- a/test/middlewares/query.test.js
+++ b/test/middlewares/query.test.js
@@ -239,7 +239,7 @@ describe('query middleware', () => {
             const dispatch = () => {
                 assert.fail();
             };
-            const queryKey = getQueryKey(url);
+            const queryKey = getQueryKey({ url });
             const getState = () => ({
                 entities: {},
                 queries: {
@@ -269,7 +269,7 @@ describe('query middleware', () => {
             const dispatch = () => {
                 assert.fail();
             };
-            const queryKey = getQueryKey(url);
+            const queryKey = getQueryKey({ url });
             const getState = () => ({
                 entities: {},
                 queries: {
@@ -311,7 +311,7 @@ describe('query middleware', () => {
                 },
             ];
             const dispatch = mockDispatchToAssertActions(actionsToDispatch, done);
-            const queryKey = getQueryKey(url);
+            const queryKey = getQueryKey({ url });
             const getState = () => ({
                 entities: {},
                 queries: {
@@ -353,7 +353,7 @@ describe('query middleware', () => {
                 },
             ];
             const dispatch = mockDispatchToAssertActions(actionsToDispatch, done);
-            const queryKey = getQueryKey(url);
+            const queryKey = getQueryKey({ url });
             const getState = () => ({
                 entities: {},
                 queries: {
@@ -660,7 +660,7 @@ describe('query middleware', () => {
                     done();
                 },
             };
-            const queryKey = getQueryKey(url);
+            const queryKey = getQueryKey({ url });
             const getState = () => ({
                 entities: {},
                 queries: {
@@ -692,7 +692,7 @@ describe('query middleware', () => {
                     done();
                 },
             };
-            const queryKey = getQueryKey(url);
+            const queryKey = getQueryKey({ url });
             const getState = () => ({
                 entities: {},
                 queries: {

--- a/test/middlewares/query.test.js
+++ b/test/middlewares/query.test.js
@@ -1,6 +1,7 @@
 import { assert } from 'chai';
 import superagent from 'superagent';
 import superagentMock from 'superagent-mock';
+import omit from 'lodash.omit';
 
 import * as actionTypes from '../../src/constants/action-types';
 import { getQueryKey } from '../../src/lib/query-key';
@@ -42,7 +43,9 @@ const superagentMockConfig = [
     {
         pattern: '/echo-headers',
         fixtures: (match, params, headers) => {
-            return headers;
+            // Remove the User-Agent header automatically added by superagent
+
+            return omit(headers, 'User-Agent');
         },
         get: mockEndpointForHeaders,
         post: mockEndpointForHeaders,

--- a/test/middlewares/query.test.js
+++ b/test/middlewares/query.test.js
@@ -671,7 +671,7 @@ describe('query middleware', () => {
                 queries: {
                     [queryKey]: {
                         isPending: true,
-                        request: mockRequestObject,
+                        networkHandler: mockRequestObject,
                     },
                 },
             });
@@ -704,7 +704,7 @@ describe('query middleware', () => {
                     [queryKey]: {
                         isPending: true,
                         isMutation: true,
-                        request: mockRequestObject,
+                        networkHandler: mockRequestObject,
                     },
                 },
             });
@@ -744,11 +744,11 @@ describe('query middleware', () => {
                 queries: {
                     '/api1': {
                         isPending: true,
-                        request: mockRequestObject,
+                        networkHandler: mockRequestObject,
                     },
                     '/api2': {
                         isPending: true,
-                        request: mockRequestObject,
+                        networkHandler: mockRequestObject,
                     },
                 },
             });

--- a/test/network-interfaces/superagent.test.js
+++ b/test/network-interfaces/superagent.test.js
@@ -1,6 +1,6 @@
 import { assert } from 'chai';
 import * as HTTPMethods from '../../src/constants/http-methods';
-import superagentAdapter from '../../src/adapters/superagent';
+import superagentAdapter from '../../src/network-interfaces/superagent';
 
 describe('superagent adapter', () => {
     it('must return an object with both execute and abort functions, as well as the request instance', () => {

--- a/test/network-interfaces/superagent.test.js
+++ b/test/network-interfaces/superagent.test.js
@@ -1,47 +1,47 @@
 import { assert } from 'chai';
 import * as HTTPMethods from '../../src/constants/http-methods';
-import superagentAdapter from '../../src/network-interfaces/superagent';
+import superagentInterface from '../../src/network-interfaces/superagent';
 
-describe('superagent adapter', () => {
+describe('superagent interface', () => {
     it('must return an object with both execute and abort functions, as well as the request instance', () => {
-        const adapter = superagentAdapter('http://localhost', HTTPMethods.GET);
-        assert.isFunction(adapter.execute);
-        assert.isFunction(adapter.abort);
-        assert(adapter.instance);
+        const networkInterface = superagentInterface('http://localhost', HTTPMethods.GET);
+        assert.isFunction(networkInterface.execute);
+        assert.isFunction(networkInterface.abort);
+        assert(networkInterface.instance);
     });
 
     it('must return a HEAD request when supplied a HEAD method', () => {
-        const { instance } = superagentAdapter('http://localhost', HTTPMethods.HEAD);
+        const { instance } = superagentInterface('http://localhost', HTTPMethods.HEAD);
         assert.equal(instance.method, HTTPMethods.HEAD);
     });
 
     it('must return a DELETE request when supplied a DELETE method', () => {
-        const { instance } = superagentAdapter('http://localhost', HTTPMethods.DELETE);
+        const { instance } = superagentInterface('http://localhost', HTTPMethods.DELETE);
         assert.equal(instance.method, HTTPMethods.DELETE);
     });
 
     it('must return a GET request when supplied a GET method', () => {
-        const { instance } = superagentAdapter('http://localhost', HTTPMethods.GET);
+        const { instance } = superagentInterface('http://localhost', HTTPMethods.GET);
         assert.equal(instance.method, HTTPMethods.GET);
     });
 
     it('must return a PATCH request when supplied a PATCH method', () => {
-        const { instance } = superagentAdapter('http://localhost', HTTPMethods.PATCH);
+        const { instance } = superagentInterface('http://localhost', HTTPMethods.PATCH);
         assert.equal(instance.method, HTTPMethods.PATCH);
     });
 
     it('must return a POST request when supplied a POST method', () => {
-        const { instance } = superagentAdapter('http://localhost', HTTPMethods.POST);
+        const { instance } = superagentInterface('http://localhost', HTTPMethods.POST);
         assert.equal(instance.method, HTTPMethods.POST);
     });
 
     it('must return a PUT request when supplied a PUT method', () => {
-        const { instance } = superagentAdapter('http://localhost', HTTPMethods.PUT);
+        const { instance } = superagentInterface('http://localhost', HTTPMethods.PUT);
         assert.equal(instance.method, HTTPMethods.PUT);
     });
 
     it('must throw an error when supplied an invalid HTTP method', () => {
-        const invalid = () => superagentAdapter('http://localhost', 'abc');
+        const invalid = () => superagentInterface('http://localhost', 'abc');
         assert.throws(invalid, /Unsupported HTTP method/);
     });
 });

--- a/test/reducers/entities.test.js
+++ b/test/reducers/entities.test.js
@@ -65,7 +65,7 @@ describe('entities reducer', () => {
             originalEntities: {
                 message: 'hello, world!',
             },
-            entities: {
+            rolledBackEntities: {
                 message: 'hello, world!',
             },
         };

--- a/test/reducers/entities.test.js
+++ b/test/reducers/entities.test.js
@@ -91,10 +91,15 @@ describe('entities reducer', () => {
         assert.deepEqual(newEntities, expectedEntities);
     });
 
-    it('should handle REMOVE_ENTITY', () => {
+    it('should handle UPDATE_ENTITIES', () => {
         const action = {
-            type: actionTypes.REMOVE_ENTITY,
-            path: ['some', 'thing', 'gone'],
+            type: actionTypes.UPDATE_ENTITIES,
+            update: {
+                some: value => ({
+                    ...value,
+                    thing: {},
+                }),
+            },
         };
         const prevState = {
             some: {
@@ -112,10 +117,19 @@ describe('entities reducer', () => {
         assert.deepEqual(newEntities, expectedEntities);
     });
 
-    it('should handle REMOVE_ENTITIES', () => {
+    it('should handle UPDATE_ENTITIES with multiple entities', () => {
         const action = {
-            type: actionTypes.REMOVE_ENTITIES,
-            paths: [['some', 'thing', 'gone'], ['something', 'else', 'gone']],
+            type: actionTypes.UPDATE_ENTITIES,
+            update: {
+                some: value => ({
+                    ...value,
+                    thing: {},
+                }),
+                something: value => ({
+                    ...value,
+                    else: {},
+                }),
+            },
         };
         const prevState = {
             some: {
@@ -128,6 +142,11 @@ describe('entities reducer', () => {
                     gone: {},
                 },
             },
+            dont: {
+                touch: {
+                    this: {},
+                },
+            },
         };
         const newEntities = entities(prevState, action);
         const expectedEntities = {
@@ -136,6 +155,11 @@ describe('entities reducer', () => {
             },
             something: {
                 else: {},
+            },
+            dont: {
+                touch: {
+                    this: {},
+                },
             },
         };
         assert.deepEqual(newEntities, expectedEntities);

--- a/test/reducers/entities.test.js
+++ b/test/reducers/entities.test.js
@@ -62,9 +62,6 @@ describe('entities reducer', () => {
     it('should handle MUTATE_FAILURE and original entities', () => {
         const action = {
             type: actionTypes.MUTATE_FAILURE,
-            originalEntities: {
-                message: 'hello, world!',
-            },
             rolledBackEntities: {
                 message: 'hello, world!',
             },

--- a/test/reducers/entities.test.js
+++ b/test/reducers/entities.test.js
@@ -65,6 +65,9 @@ describe('entities reducer', () => {
             originalEntities: {
                 message: 'hello, world!',
             },
+            entities: {
+                message: 'hello, world!',
+            },
         };
         const prevState = {
             message: 'hello, optimistic world!',

--- a/test/reducers/errors.test.js
+++ b/test/reducers/errors.test.js
@@ -1,0 +1,178 @@
+import { assert } from 'chai';
+
+import * as actionTypes from '../../src/constants/action-types';
+import errors from '../../src/reducers/errors';
+
+describe('errors reducer', () => {
+    it('should record body, text, headers on REQUEST_FAILURE', () => {
+        const action = {
+            type: actionTypes.REQUEST_FAILURE,
+            queryKey: '{"url":"/hello"}',
+            responseBody: {
+                error: 'please stop',
+            },
+            responseText: '{"error":"please stop"}',
+            responseHeaders: {
+                hello: 'world',
+            },
+        };
+        const prevState = {
+            '{"url":"/test"}': {
+                responseBody: {
+                    test: 'a',
+                },
+                responseText: '{"test":"a"}',
+                responseHeaders: {},
+            },
+        };
+        const newState = errors(prevState, action);
+        const expectedState = {
+            '{"url":"/hello"}': {
+                responseBody: {
+                    error: 'please stop',
+                },
+                responseText: '{"error":"please stop"}',
+                responseHeaders: {
+                    hello: 'world',
+                },
+            },
+            '{"url":"/test"}': {
+                responseBody: {
+                    test: 'a',
+                },
+                responseText: '{"test":"a"}',
+                responseHeaders: {},
+            },
+        };
+        assert.deepEqual(newState, expectedState);
+    });
+
+    it('should record body, text, headers on MUTATE_FAILURE', () => {
+        const action = {
+            type: actionTypes.MUTATE_FAILURE,
+            queryKey: '{"url":"/change-name","body":{"name":"Ryan"}}',
+            responseBody: {
+                error: 'invalid name',
+            },
+            responseText: '{"error":"invalid name"}',
+            responseHeaders: {},
+        };
+        const prevState = {
+            '{"url":"/test"}': {
+                responseBody: {
+                    test: 'a',
+                },
+                responseText: '{"test":"a"}',
+                responseHeaders: {},
+            },
+        };
+        const newState = errors(prevState, action);
+        const expectedState = {
+            '{"url":"/test"}': {
+                responseBody: {
+                    test: 'a',
+                },
+                responseText: '{"test":"a"}',
+                responseHeaders: {},
+            },
+            '{"url":"/change-name","body":{"name":"Ryan"}}': {
+                responseBody: {
+                    error: 'invalid name',
+                },
+                responseText: '{"error":"invalid name"}',
+                responseHeaders: {},
+            },
+        };
+        assert.deepEqual(newState, expectedState);
+    });
+
+    it('should remove state for query on REQUEST_START', () => {
+        const action = {
+            type: actionTypes.REQUEST_START,
+            queryKey: '{"url":"/hello"}',
+        };
+        const prevState = {
+            '{"url":"/test"}': {
+                responseBody: {
+                    test: 'a',
+                },
+                responseText: '{"test":"a"}',
+                responseHeaders: {},
+            },
+            '{"url":"/hello"}': {
+                responseBody: {
+                    hello: 'world!',
+                },
+                responseText: '{"hello":"world"}',
+                responseHeaders: {
+                    hello: 'world',
+                },
+            },
+        };
+        const newState = errors(prevState, action);
+        const expectedState = {
+            '{"url":"/test"}': {
+                responseBody: {
+                    test: 'a',
+                },
+                responseText: '{"test":"a"}',
+                responseHeaders: {},
+            },
+        };
+        assert.deepEqual(newState, expectedState);
+    });
+
+    it('should remove state for query on MUTATE_START', () => {
+        const action = {
+            type: actionTypes.MUTATE_START,
+            queryKey: '{"url":"/change-name","body":{"name":"Ryan"}}',
+        };
+        const prevState = {
+            '{"url":"/test"}': {
+                responseBody: {
+                    test: 'a',
+                },
+                responseText: '{"test":"a"}',
+                responseHeaders: {},
+            },
+            '{"url":"/change-name","body":{"name":"Ryan"}}': {
+                responseBody: {
+                    error: 'invalid name',
+                },
+                responseText: '{"error":"invalid name"}',
+                responseHeaders: {},
+            },
+        };
+        const newState = errors(prevState, action);
+        const expectedState = {
+            '{"url":"/test"}': {
+                responseBody: {
+                    test: 'a',
+                },
+                responseText: '{"test":"a"}',
+                responseHeaders: {},
+            },
+        };
+        assert.deepEqual(newState, expectedState);
+    });
+
+    it('should handle RESET', () => {
+        const action = {
+            type: actionTypes.RESET,
+        };
+        const prevState = {
+            '{"url":"/hello"}': {
+                responseBody: {
+                    hello: 'world!',
+                },
+                responseText: '{"hello":"world"}',
+                responseHeaders: {
+                    hello: 'world',
+                },
+            },
+        };
+        const newState = errors(prevState, action);
+        const expectedState = {};
+        assert.deepEqual(newState, expectedState);
+    });
+});

--- a/test/selectors/query.test.js
+++ b/test/selectors/query.test.js
@@ -5,15 +5,6 @@ import * as querySelectors from '../../src/selectors/query';
 
 describe('query selectors', () => {
     describe('isFinished', () => {
-        it('should work with just url', () => {
-            const isFinished = querySelectors.isFinished('/api/dashboards')({
-                '{"url":"/api/dashboards"}': {
-                    isFinished: true,
-                },
-            });
-            assert.isTrue(isFinished);
-        });
-
         it('should work with a config', () => {
             const queryConfig = {
                 url: '/api/dashboard/1/rename',
@@ -21,12 +12,15 @@ describe('query selectors', () => {
                     name: 'My KPIs',
                 },
             };
-            const queryKey = getQueryKey(queryConfig.url, queryConfig.body);
-            const isFinished = querySelectors.isFinished(queryConfig)({
-                [queryKey]: {
-                    isFinished: true,
+            const queryKey = getQueryKey(queryConfig);
+            const isFinished = querySelectors.isFinished(
+                {
+                    [queryKey]: {
+                        isFinished: true,
+                    },
                 },
-            });
+                queryConfig
+            );
             assert.isTrue(isFinished);
         });
 
@@ -38,25 +32,19 @@ describe('query selectors', () => {
                 },
                 queryKey: 'myQueryKey',
             };
-            const isFinished = querySelectors.isFinished(queryConfig)({
-                myQueryKey: {
-                    isFinished: true,
+            const isFinished = querySelectors.isFinished(
+                {
+                    myQueryKey: {
+                        isFinished: true,
+                    },
                 },
-            });
+                queryConfig
+            );
             assert.isTrue(isFinished);
         });
     });
 
     describe('isPending', () => {
-        it('should work with just url', () => {
-            const isPending = querySelectors.isPending('/api/dashboards')({
-                '{"url":"/api/dashboards"}': {
-                    isPending: true,
-                },
-            });
-            assert.isTrue(isPending);
-        });
-
         it('should work with a config', () => {
             const queryConfig = {
                 url: '/api/dashboard/1/rename',
@@ -64,12 +52,15 @@ describe('query selectors', () => {
                     name: 'My KPIs',
                 },
             };
-            const queryKey = getQueryKey(queryConfig.url, queryConfig.body);
-            const isPending = querySelectors.isPending(queryConfig)({
-                [queryKey]: {
-                    isPending: true,
+            const queryKey = getQueryKey(queryConfig);
+            const isPending = querySelectors.isPending(
+                {
+                    [queryKey]: {
+                        isPending: true,
+                    },
                 },
-            });
+                queryConfig
+            );
             assert.isTrue(isPending);
         });
 
@@ -81,25 +72,19 @@ describe('query selectors', () => {
                 },
                 queryKey: 'myQueryKey',
             };
-            const isPending = querySelectors.isPending(queryConfig)({
-                myQueryKey: {
-                    isPending: true,
+            const isPending = querySelectors.isPending(
+                {
+                    myQueryKey: {
+                        isPending: true,
+                    },
                 },
-            });
+                queryConfig
+            );
             assert.isTrue(isPending);
         });
     });
 
     describe('status', () => {
-        it('should work with just url', () => {
-            const status = querySelectors.status('/api/dashboards')({
-                '{"url":"/api/dashboards"}': {
-                    status: 200,
-                },
-            });
-            assert.equal(status, 200);
-        });
-
         it('should work with a config', () => {
             const queryConfig = {
                 url: '/api/dashboard/1/rename',
@@ -107,12 +92,15 @@ describe('query selectors', () => {
                     name: 'My KPIs',
                 },
             };
-            const queryKey = getQueryKey(queryConfig.url, queryConfig.body);
-            const status = querySelectors.status(queryConfig)({
-                [queryKey]: {
-                    status: 200,
+            const queryKey = getQueryKey(queryConfig);
+            const status = querySelectors.status(
+                {
+                    [queryKey]: {
+                        status: 200,
+                    },
                 },
-            });
+                queryConfig
+            );
             assert.equal(status, 200);
         });
 
@@ -124,25 +112,19 @@ describe('query selectors', () => {
                 },
                 queryKey: 'myQueryKey',
             };
-            const status = querySelectors.status(queryConfig)({
-                myQueryKey: {
-                    status: 200,
+            const status = querySelectors.status(
+                {
+                    myQueryKey: {
+                        status: 200,
+                    },
                 },
-            });
+                queryConfig
+            );
             assert.equal(status, 200);
         });
     });
 
     describe('lastUpdated', () => {
-        it('should work with just url', () => {
-            const lastUpdated = querySelectors.lastUpdated('/api/dashboards')({
-                '{"url":"/api/dashboards"}': {
-                    lastUpdated: 1488471746117,
-                },
-            });
-            assert.equal(lastUpdated, 1488471746117);
-        });
-
         it('should work with a config', () => {
             const queryConfig = {
                 url: '/api/dashboard/1/rename',
@@ -150,12 +132,15 @@ describe('query selectors', () => {
                     name: 'My KPIs',
                 },
             };
-            const queryKey = getQueryKey(queryConfig.url, queryConfig.body);
-            const lastUpdated = querySelectors.lastUpdated(queryConfig)({
-                [queryKey]: {
-                    lastUpdated: 1488471746117,
+            const queryKey = getQueryKey(queryConfig);
+            const lastUpdated = querySelectors.lastUpdated(
+                {
+                    [queryKey]: {
+                        lastUpdated: 1488471746117,
+                    },
                 },
-            });
+                queryConfig
+            );
             assert.equal(lastUpdated, 1488471746117);
         });
 
@@ -167,25 +152,19 @@ describe('query selectors', () => {
                 },
                 queryKey: 'myQueryKey',
             };
-            const lastUpdated = querySelectors.lastUpdated(queryConfig)({
-                myQueryKey: {
-                    lastUpdated: 1488471746117,
+            const lastUpdated = querySelectors.lastUpdated(
+                {
+                    myQueryKey: {
+                        lastUpdated: 1488471746117,
+                    },
                 },
-            });
+                queryConfig
+            );
             assert.equal(lastUpdated, 1488471746117);
         });
     });
 
     describe('queryCount', () => {
-        it('should work with just url', () => {
-            const queryCount = querySelectors.queryCount('/api/dashboards')({
-                '{"url":"/api/dashboards"}': {
-                    queryCount: 2,
-                },
-            });
-            assert.equal(queryCount, 2);
-        });
-
         it('should work with a config', () => {
             const queryConfig = {
                 url: '/api/dashboard/1/rename',
@@ -193,12 +172,15 @@ describe('query selectors', () => {
                     name: 'My KPIs',
                 },
             };
-            const queryKey = getQueryKey(queryConfig.url, queryConfig.body);
-            const queryCount = querySelectors.queryCount(queryConfig)({
-                [queryKey]: {
-                    queryCount: 2,
+            const queryKey = getQueryKey(queryConfig);
+            const queryCount = querySelectors.queryCount(
+                {
+                    [queryKey]: {
+                        queryCount: 2,
+                    },
                 },
-            });
+                queryConfig
+            );
             assert.equal(queryCount, 2);
         });
 
@@ -210,11 +192,14 @@ describe('query selectors', () => {
                 },
                 queryKey: 'myQueryKey',
             };
-            const queryCount = querySelectors.queryCount(queryConfig)({
-                myQueryKey: {
-                    queryCount: 2,
+            const queryCount = querySelectors.queryCount(
+                {
+                    myQueryKey: {
+                        queryCount: 2,
+                    },
                 },
-            });
+                queryConfig
+            );
             assert.equal(queryCount, 2);
         });
     });


### PR DESCRIPTION
In addition to the things mentioned in https://github.com/amplitude/redux-query/issues/70:

- update superagent to latest stable version - 3.x (which fixes #71)
- rename confusingly named "request" field stored in queries reducer and in the start actions to "networkHandler"
- rename "network adapters" to "network interfaces", moved adapters/superagent to network-interfaces/superagent to reflect this change
- updated the README to document queries selectors and the return values from dispatching requestAsync and mutateAsync actions