### PR TITLE
TypeScript definitions

### DIFF
--- a/advanced.d.ts
+++ b/advanced.d.ts
@@ -1,0 +1,295 @@
+import { Middleware, Reducer } from 'redux';
+import { ComponentClass, ComponentType } from 'react';
+
+// http://ideasintosoftware.com/typescript-advanced-tricks/
+type Diff<T extends string, U extends string> = ({ [P in T]: P } &
+  { [P in U]: never } & { [x: string]: never })[T];
+type Omit<T, K extends keyof T> = { [P in Diff<keyof T, K>]: T[P] };
+
+export enum Credentials {
+  Omit = 'omit',
+  Include = 'include',
+}
+
+export interface RequestConfig {
+  /** The URL for the HTTP request. */
+  url: string;
+
+  /** An object where keys are entity IDs and values are "update functions" */
+  update: { [key: string]: (prevValue: any, transformedValue: any) => any };
+
+  /**
+   * The request body. For GETs, this object is stringified and appended
+   * to the URL as query params.
+   */
+  body?: any;
+
+  /**
+   * The identifier used to identify the query metadata in the queries
+   * reducer. If unprovided, the url and body fields are serialized to
+   * generate the query key.
+   */
+  queryKey?: string;
+
+  /**
+   * Options for the request. Set options.method to change the HTTP method,
+   * options.headers to set any headers and options.credentials = 'include'
+   * for CORS.
+   */
+  options?: {
+    method?: string;
+    headers?: any;
+    credentials?: Credentials;
+    [others: string]: any;
+  };
+
+  /**
+   * A function that transforms the response data to an entities object
+   * where keys are entity IDs and values are entity data. Can be used to
+   * normalize data.
+   */
+  transform?: (
+    responseJson: any,
+    responseText: string,
+  ) => { [key: string]: any };
+
+  /**
+   * A flag to indicate that the request should be performed even if a
+   * previous query with the same query key succeeded.
+   */
+  force?: boolean;
+
+  /**
+   * Various metadata for the query. Can be used to update other reducers
+   * when queries succeed or fail.
+   */
+  meta?: any;
+}
+
+export type OptimisticUpdate = { [key: string]: (prevValue: any) => any };
+
+export interface MutateConfig extends RequestConfig {
+  /**
+   * An object where keys are entity IDs and values are "optimisticUpdate
+   * functions". Used to update entities immediately when the mutation
+   * starts.
+   */
+  optimisticUpdate?: OptimisticUpdate;
+
+  /**
+   * An object where keys are entity IDs and values are "rollback functions".
+   * Used to reverse the effects of optimisticUpdate when the mutation
+   * fails. If not provided, the entity will simply be reverted to its value
+   * before the optimisticUpdate was performed.
+   */
+  rollback?: { [key: string]: (initialValue: any, currentValue: any) => any };
+}
+
+export enum ActionType {
+  RequestAsync = '@@query/REQUEST_ASYNC',
+  RequestStart = '@@query/REQUEST_START',
+  RequestSuccess = '@@query/REQUEST_SUCCESS',
+  RequestFailure = '@@query/REQUEST_FAILURE',
+  CancelQuery = '@@query/CANCEL_QUERY',
+  MutateAsync = '@@query/MUTATE_ASYNC',
+  MutateStart = '@@query/MUTATE_START',
+  MutateSuccess = '@@query/MUTATE_SUCCESS',
+  MutateFailure = '@@query/MUTATE_FAILURE',
+  Reset = '@@query/RESET',
+  UpdateEntities = '@@query/UPDATE_ENTITIES',
+}
+
+export enum HttpMethod {
+  Delete = 'DELETE',
+  Get = 'GET',
+  Head = 'HEAD',
+  Post = 'POST',
+  Put = 'PUT',
+  Patch = 'PATCH',
+}
+
+export namespace httpMethods {
+  export const DELETE: HttpMethod.Delete;
+  export const GET: HttpMethod.Get;
+  export const HEAD: HttpMethod.Head;
+  export const POST: HttpMethod.Post;
+  export const PUT: HttpMethod.Put;
+  export const PATCH: HttpMethod.Patch;
+}
+
+export namespace actionTypes {
+  export const REQUEST_ASYNC: ActionType.RequestAsync;
+  export const REQUEST_START: ActionType.RequestStart;
+  export const REQUEST_SUCCESS: ActionType.RequestSuccess;
+  export const REQUEST_FAILURE: ActionType.RequestFailure;
+  export const CANCEL_QUERY: ActionType.CancelQuery;
+  export const MUTATE_ASYNC: ActionType.MutateAsync;
+  export const MUTATE_START: ActionType.MutateStart;
+  export const MUTATE_SUCCESS: ActionType.MutateSuccess;
+  export const MUTATE_FAILURE: ActionType.MutateFailure;
+  export const RESET: ActionType.Reset;
+  export const UPDATE_ENTITIES: ActionType.UpdateEntities;
+}
+
+export interface Selector<V = any> {
+  (state: any, config: Partial<RequestConfig>): V | undefined;
+}
+
+declare namespace errorSelectors {
+  /** Parsed response body (if query failed) */
+  export const responseBody: Selector<any>;
+
+  /** Unparsed response body string (if query failed) */
+  export const responseText: Selector<string>;
+
+  /** Response headers (if query failed) */
+  export const responseHeaders: Selector<any>;
+}
+
+declare namespace querySelectors {
+  /** Returns true if the query was resolved or cancelled */
+  export const isFinished: Selector<boolean>;
+
+  /** Returns true if the query is in-flight – not resolved and not cancelled */
+  export const isPending: Selector<boolean>;
+
+  /** Response HTTP status code */
+  export const status: Selector<number>;
+
+  /** Time at which the query was resolved */
+  export const lastUpdated: Selector<number>;
+
+  /** Number of times a query was started with the same query key */
+  export const queryCount: Selector<number>;
+}
+
+export const getQueryKey: (args: Partial<RequestConfig>) => string;
+
+export const queriesReducer: Reducer<any>;
+export const entitiesReducer: Reducer<any>;
+export const errorsReducer: Reducer<any>;
+
+export interface Action<T> {
+  type: T;
+}
+
+// Action Types
+
+export interface RequestAsync
+  extends RequestConfig,
+    Action<ActionType.RequestAsync> {}
+
+export interface MutateAsync
+  extends MutateConfig,
+    Action<ActionType.MutateAsync> {}
+
+export interface CancelQuery extends Action<ActionType.CancelQuery> {
+  queryKey: string;
+}
+
+export interface UpdateEntities extends Action<ActionType.UpdateEntities> {
+  update: OptimisticUpdate;
+}
+
+/**
+ * Similarly to how mutations are triggered by dispatching mutateAsync
+ * actions, you can trigger requests by dispatching requestAsync actions
+ * with a request query config.
+ *
+ * You can also Promise-chain on dispatched requestAsync actions, but a
+ * Promise will only be returned if redux-query determines it will make a
+ * network request. For example, if the query config does not have force
+ * set to true and a previous request with the same query key previously
+ * succeeded, then a Promise will not be returned. So be sure to always
+ * check that the returned value from a dispatched requestAsync is a Promise
+ * before interacting with it.
+ */
+export const requestAsync: (config: RequestConfig) => RequestAsync;
+
+/**
+ * Dispatch mutateAsync Redux actions to trigger mutations. mutateAsync
+ * takes a mutation query config as its only argument.
+ *
+ * When dispatching a mutateAsync action, you can Promise-chain on the
+ * returned value from dispatch.
+ */
+export const mutateAsync: (config: MutateConfig) => MutateAsync;
+
+export const cancelQuery: (queryKey: string) => CancelQuery;
+export const updateEntities: (update: OptimisticUpdate) => UpdateEntities;
+
+export interface NetworkConfig {
+  body?: any;
+  headers?: any;
+  credentials?: Credentials;
+}
+
+export interface NetworkHandlerCallback {
+  (
+    err: any,
+    resStatus: number,
+    resBody: any,
+    resText: string,
+    resHeaders: any,
+  ): void;
+}
+
+export interface NetworkHandler {
+  execute: (callback: NetworkHandlerCallback) => void;
+  abort: () => void;
+}
+
+export interface NetworkInterface {
+  (url: string, method: HttpMethod, config: NetworkConfig): NetworkHandler;
+}
+
+export interface MiddlewareConfig {
+  backoff: {
+    maxAttempts: number;
+    minDuration: number;
+    maxDuration: number;
+  };
+
+  retryableStatusCodes: number[];
+}
+
+/**
+ * queryMiddleware requires two arguments: a selector (or function) that
+ * returns entities state, and a function for the queries state.
+ */
+export interface QueryMiddleware {
+  (
+    queriesSelector: any,
+    entitiesSelector: any,
+    config?: MiddlewareConfig,
+  ): Middleware;
+}
+
+export const queryMiddlewareAdvanced: (
+  networkInterface: NetworkInterface,
+) => QueryMiddleware;
+
+export interface ConnectRequestOptions {
+  pure?: boolean;
+  withRef?: boolean;
+}
+
+export type MapPropsToConfigParam<P> = (
+  props: P,
+) => RequestConfig & { url?: string };
+
+export interface ForceRequestProp {
+  forceRequest: () => void;
+}
+
+export interface ComponentDecorator {
+  <P extends ForceRequestProp>(component: ComponentType<P>): ComponentClass<
+    Omit<P, keyof ForceRequestProp>
+  >;
+}
+
+export interface ConnectRequest {
+  <P = {}>(mapPropsToConfig: MapPropsToConfigParam<P>): ComponentDecorator;
+}
+
+export const connectRequest: ConnectRequest;

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,5 @@
+export * from './advanced';
+
+import { QueryMiddleware } from './advanced';
+
+export const queryMiddleware: QueryMiddleware;

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "homepage": "https://github.com/amplitude/redux-query",
   "main": "dist/commonjs/index.js",
   "module": "dist/es/index.js",
+  "typings": "./index.d.ts",
   "jsnext:main": "dist/es/index.js",
   "scripts": {
     "build:commonjs": "npm run clean:commonjs && cross-env NODE_ENV=production cross-env BABEL_ENV=commonjs babel src --out-dir dist/commonjs --ignore examples/,test/",

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "redux": "^2.0.0 || ^3.0.0"
   },
   "devDependencies": {
+    "@types/react-redux": "^5.0.10",
     "babel-cli": "6.8.0",
     "babel-core": "^6.5.1",
     "babel-eslint": "^7.1.1",
@@ -80,8 +81,11 @@
     "nyc": "^10.0.0",
     "prettier": "^1.3.1",
     "react": "^16.0.0",
+    "redux": "^3.7.2",
     "rimraf": "^2.4.3",
     "superagent-mock": "^3.3.0",
+    "typescript": "^2.5.3",
+    "typescript-definition-tester": "^0.0.5",
     "webpack": "^1.9.6"
   }
 }

--- a/test/typescript/definitions.test.js
+++ b/test/typescript/definitions.test.js
@@ -1,0 +1,12 @@
+import * as path from 'path';
+import * as tt from 'typescript-definition-tester';
+
+const options = {
+  jsx: 'react'
+};
+
+describe('typescript definitions', () => {
+  it('should compile', done => {
+    tt.compile(path.resolve(__dirname, 'definitions.tsx'), options, done);
+  }).timeout(3000);
+});

--- a/test/typescript/definitions.tsx
+++ b/test/typescript/definitions.tsx
@@ -1,0 +1,107 @@
+import * as React from 'react';
+import { connect } from 'react-redux';
+import { applyMiddleware, combineReducers, compose, createStore } from 'redux';
+
+import { queryMiddlewareAdvanced } from '../../advanced';
+import {
+  connectRequest,
+  ForceRequestProp,
+  NetworkInterface,
+  queryMiddleware,
+  querySelectors,
+  RequestConfig,
+} from '../../index';
+
+export interface Article {
+  id: number;
+  title: string;
+}
+
+export interface State {
+  entities: {
+    articles?: { [key: string]: Article };
+  };
+  queries: any;
+}
+
+export const getEntities = (state: State) => state.entities;
+export const getQueries = (state: State) => state.queries;
+
+export const getArticles = (state: State) => state.entities.articles;
+export const getArticleList = (state: State) => {
+  const articles = getArticles(state);
+  return Object.keys(articles).map(k => articles[k]);
+};
+
+const reducer = combineReducers({ entities: getEntities, queries: getQueries });
+export const store = createStore(
+  reducer,
+  applyMiddleware(queryMiddleware(getQueries, getEntities)),
+);
+
+const dummyNetworkInterface: NetworkInterface = (url, method, config) => {
+  const body = { message: 'ok' };
+  return {
+    execute: callback => {
+      callback(null, 200, body, JSON.stringify(body), {});
+    },
+    abort: () => {},
+  };
+};
+
+export const middleware = queryMiddlewareAdvanced(dummyNetworkInterface);
+
+// Component
+
+export interface OwnProps {
+  categorySlug: string;
+}
+
+export interface StateProps {
+  articleList: any[];
+  queryConfig: RequestConfig;
+}
+
+export type RequestProps = OwnProps & StateProps;
+export type Props = RequestProps & ForceRequestProp;
+
+const Category: React.SFC<Props> = props => (
+  <div>
+    <h1>Category: {props.categorySlug}</h1>
+    {props.articleList.map(article => (
+      <article key={article.id}>
+        <h1>{article.title}</h1>
+      </article>
+    ))}
+    <button onClick={props.forceRequest}>Load new articles</button>
+  </div>
+);
+
+const getQueryConfig = (categorySlug: string): RequestConfig => ({
+  url: '/publications/' + categorySlug + '/articles',
+  update: {
+    articles: (prevValue, transformedValue) => ({
+      ...prevValue,
+      ...transformedValue,
+    }),
+  },
+});
+
+const CategoryContainer = compose(
+  connect<StateProps, undefined, OwnProps>((state, ownProps) => ({
+    articleList: getArticleList(state),
+    isFinished: querySelectors.isFinished(
+      getQueries(state),
+      getQueryConfig(ownProps.categorySlug),
+    ),
+    queryConfig: getQueryConfig(ownProps.categorySlug),
+  })),
+  connectRequest<StateProps>(props => props.queryConfig),
+)(Category);
+
+export default () => (
+  <div>
+    <CategoryContainer categorySlug="redux" />
+    <CategoryContainer categorySlug="react" />
+  </div>
+);

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,17 @@
 # yarn lockfile v1
 
 
+"@types/react-redux@^5.0.10":
+  version "5.0.10"
+  resolved "https://registry.yarnpkg.com/@types/react-redux/-/react-redux-5.0.10.tgz#f5c45a349f759d87d6b1f2aa096a756561a6d5c9"
+  dependencies:
+    "@types/react" "*"
+    redux "^3.6.0"
+
+"@types/react@*":
+  version "16.0.11"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-16.0.11.tgz#ab505dc60bd1dcd6113577d71d1c96e58b6bd9f0"
+
 abbrev@1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-1.1.1.tgz#f8f2c887ad10bf67f634f005b6987fed3179aac8"
@@ -936,7 +947,7 @@ boom@5.x.x:
   dependencies:
     hoek "4.x.x"
 
-brace-expansion@^1.1.7:
+brace-expansion@^1.0.0, brace-expansion@^1.1.7:
   version "1.1.8"
   resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.8.tgz#c07b211c7c952ec1f8efd51a77ef0d1d3990a292"
   dependencies:
@@ -1346,6 +1357,13 @@ delegates@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/delegates/-/delegates-1.0.0.tgz#84c6e159b81904fdca59a0ef44cd870d31250f9a"
 
+detect-indent@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/detect-indent/-/detect-indent-0.2.0.tgz#042914498979ac2d9f3c73e4ff3e6877d3bc92b6"
+  dependencies:
+    get-stdin "^0.1.0"
+    minimist "^0.1.0"
+
 detect-indent@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/detect-indent/-/detect-indent-4.0.0.tgz#f76d064352cdf43a1cb6ce619c4ee3a9475de208"
@@ -1373,6 +1391,14 @@ doctrine@^2.0.0:
 domain-browser@^1.1.1:
   version "1.1.7"
   resolved "https://registry.yarnpkg.com/domain-browser/-/domain-browser-1.1.7.tgz#867aa4b093faa05f1de08c06f4d7b21fdf8698bc"
+
+dts-bundle@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/dts-bundle/-/dts-bundle-0.2.0.tgz#e165e494b00f81a3b6eb64385cbf6d1b486b7a99"
+  dependencies:
+    detect-indent "^0.2.0"
+    glob "^4.0.2"
+    mkdirp "^0.5.0"
 
 ecc-jsbn@~0.1.1:
   version "0.1.1"
@@ -1861,6 +1887,10 @@ get-caller-file@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-1.0.2.tgz#f702e63127e7e231c160a80c1554acb70d5047e5"
 
+get-stdin@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/get-stdin/-/get-stdin-0.1.0.tgz#5998af24aafc802d15c82c685657eeb8b10d4a91"
+
 get-stdin@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/get-stdin/-/get-stdin-4.0.1.tgz#b968c6b0a04384324902e8bf1a5df32579a450fe"
@@ -1902,6 +1932,15 @@ glob@3.2.11:
   dependencies:
     inherits "2"
     minimatch "0.3"
+
+glob@^4.0.2:
+  version "4.5.3"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-4.5.3.tgz#c6cb73d3226c1efef04de3c56d012f03377ee15f"
+  dependencies:
+    inflight "^1.0.4"
+    inherits "2"
+    minimatch "^2.0.1"
+    once "^1.3.0"
 
 glob@^5.0.5:
   version "5.0.15"
@@ -2517,6 +2556,10 @@ locate-path@^2.0.0:
     p-locate "^2.0.0"
     path-exists "^3.0.0"
 
+lodash-es@^4.2.1:
+  version "4.17.4"
+  resolved "https://registry.yarnpkg.com/lodash-es/-/lodash-es-4.17.4.tgz#dcc1d7552e150a0640073ba9cb31d70f032950e7"
+
 lodash._baseassign@^3.0.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz#8c38a099500f215ad09e59f1722fd0c52bfe0a4e"
@@ -2616,11 +2659,11 @@ lodash.values@^4.3.0:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/lodash.values/-/lodash.values-4.3.0.tgz#a3a6c2b0ebecc5c2cba1c17e6e620fe81b53d347"
 
-lodash@^3.2.0:
+lodash@^3.2.0, lodash@^3.6.0:
   version "3.10.1"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-3.10.1.tgz#5bf45e8e49ba4189e17d482789dfd15bd140b7b6"
 
-lodash@^4.0.0, lodash@^4.14.0, lodash@^4.17.4, lodash@^4.3.0:
+lodash@^4.0.0, lodash@^4.14.0, lodash@^4.17.4, lodash@^4.2.1, lodash@^4.3.0:
   version "4.17.4"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
 
@@ -2757,9 +2800,19 @@ minimatch@0.3:
   dependencies:
     brace-expansion "^1.1.7"
 
+minimatch@^2.0.1:
+  version "2.0.10"
+  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-2.0.10.tgz#8d087c39c6b38c001b97fca7ce6d0e1e80afbac7"
+  dependencies:
+    brace-expansion "^1.0.0"
+
 minimist@0.0.8:
   version "0.0.8"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.8.tgz#857fcabfc3397d2625b8228262e86aa7a011b05d"
+
+minimist@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.1.0.tgz#99df657a52574c21c9057497df742790b2b4c0de"
 
 minimist@^1.1.0, minimist@^1.1.3, minimist@^1.2.0:
   version "1.2.0"
@@ -3322,6 +3375,15 @@ redent@^1.0.0:
     indent-string "^2.1.0"
     strip-indent "^1.0.1"
 
+redux@^3.6.0, redux@^3.7.2:
+  version "3.7.2"
+  resolved "https://registry.yarnpkg.com/redux/-/redux-3.7.2.tgz#06b73123215901d25d065be342eb026bc1c8537b"
+  dependencies:
+    lodash "^4.2.1"
+    lodash-es "^4.2.1"
+    loose-envify "^1.1.0"
+    symbol-observable "^1.0.3"
+
 regenerate@^1.2.1:
   version "1.3.3"
   resolved "https://registry.yarnpkg.com/regenerate/-/regenerate-1.3.3.tgz#0c336d3980553d755c39b586ae3b20aa49c82b7f"
@@ -3762,6 +3824,10 @@ supports-color@^3.1.0, supports-color@^3.1.2:
   dependencies:
     has-flag "^1.0.0"
 
+symbol-observable@^1.0.3:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-1.0.4.tgz#29bf615d4aa7121bdd898b22d4b3f9bc4e2aa03d"
+
 table@^3.7.8:
   version "3.8.3"
   resolved "https://registry.yarnpkg.com/table/-/table-3.8.3.tgz#2bbc542f0fda9861a755d3947fefd8b3f513855f"
@@ -3889,6 +3955,18 @@ type-detect@^1.0.0:
 typedarray@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
+
+typescript-definition-tester@^0.0.5:
+  version "0.0.5"
+  resolved "https://registry.yarnpkg.com/typescript-definition-tester/-/typescript-definition-tester-0.0.5.tgz#91c574d78ea05b81ed81244d50ec30d8240c356f"
+  dependencies:
+    assertion-error "^1.0.1"
+    dts-bundle "^0.2.0"
+    lodash "^3.6.0"
+
+typescript@^2.5.3:
+  version "2.5.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.5.3.tgz#df3dcdc38f3beb800d4bc322646b04a3f6ca7f0d"
 
 ua-parser-js@^0.7.9:
   version "0.7.17"


### PR DESCRIPTION
This PR would add TypeScript definitions for the exports in `redux-query/advanced` and `redux-query`, respectively.

This includes some sample definition tests that use the types, which does pull in `redux` and `react-redux` as dev dependencies to demonstrate usage together with `compose` and `connect`. These tests are run using typescript-definition-tester.

If you would prefer not to bundle these definitions with your main project (maintenance/endorsement issues), I could submit these to DefinitelyTyped as a @types package instead.