### PR TITLE
Force on mount option

### DIFF
--- a/src/components/connect-request.js
+++ b/src/components/connect-request.js
@@ -24,7 +24,7 @@ const diffConfigs = (prevConfigs, configs) => {
 };
 
 const connectRequest = (mapPropsToConfigs, options = {}) => WrappedComponent => {
-  const { pure = true, withRef = false } = options;
+  const { pure = true, withRef = false, force = false } = options;
 
   class ConnectRequest extends React.Component {
     constructor() {
@@ -47,7 +47,7 @@ const connectRequest = (mapPropsToConfigs, options = {}) => WrappedComponent => 
 
     componentDidMount() {
       const configs = mapPropsToConfigs(this.props);
-      this.requestAsync(configs, false, true);
+      this.requestAsync(configs, force || !!this.props.forceRequestOnMount, true);
     }
 
     componentDidUpdate(prevProps) {


### PR DESCRIPTION
Sometimes you need to make sure the data you use in some `connectRequest` is just fetched from the server. `force` HOC option and `forceRequestOnMount` property do this thing.