### PR TITLE
Refactor TypeScript to be generic on entities.

### DIFF
--- a/packages/redux-query-react/index.d.ts
+++ b/packages/redux-query-react/index.d.ts
@@ -24,8 +24,8 @@ declare module 'redux-query-react' {
     WrappedComponent: React.ComponentType<TProps>,
   ) => React.ComponentType<Omit<TProps, 'forceRequest'>>;
 
-  export type RequestConnector = <TProps extends WithForceRequest = WithForceRequest>(
-    mapPropsToConfigs: QueryConfigsFactory,
+  export type RequestConnector = <TState, TProps extends WithForceRequest = WithForceRequest>(
+    mapPropsToConfigs: QueryConfigsFactory<TState>,
     options?: ConnectRequestOptions,
   ) => ConnectRequestWrapper<TProps>;
 

--- a/packages/redux-query-react/index.d.ts
+++ b/packages/redux-query-react/index.d.ts
@@ -8,16 +8,16 @@ declare module 'redux-query-react' {
     QueriesSelector,
   } from 'redux-query';
 
-  export type QueryConfigFactory = (...args: any[]) => QueryConfig;
-  export type QueryConfigsFactory = (...args: any[]) => QueryConfig | QueryConfig[];
+  export type QueryConfigFactory<T> = (...args: any[]) => QueryConfig<T>;
+  export type QueryConfigsFactory<T> = (...args: any[]) => QueryConfig<T> | QueryConfig<T>[];
 
   export interface ConnectRequestOptions {
     forwardRef?: boolean;
     pure?: boolean;
   }
-  export type ForceRequestCallback = () => Promise<ActionPromiseValue>;
-  export interface WithForceRequest {
-    forceRequest: ForceRequestCallback;
+  export type ForceRequestCallback<T> = () => Promise<ActionPromiseValue<T>>;
+  export interface WithForceRequest<T> {
+    forceRequest: ForceRequestCallback<T>;
   }
 
   export type ConnectRequestWrapper<TProps extends WithForceRequest> = (
@@ -35,13 +35,13 @@ declare module 'redux-query-react' {
   }
 
   export type ReduxQueryProvider = React.ComponentType<ProviderProps>;
-  export type ActionPromise = Promise<ActionPromiseValue> | undefined;
-  export type UseRequestHook = (queryConfig: QueryConfig) => [QueryState, ForceRequestCallback];
-  export type MutationQueryConfigFactory = (...args: any) => QueryConfig;
-  export type RunMutation = (...args: any) => Promise<ActionPromiseValue>;
-  export type UseMutationHook = (
-    createQueryConfig: MutationQueryConfigFactory,
-  ) => [QueryState, RunMutation];
+  export type ActionPromise<T> = Promise<ActionPromiseValue<T>> | undefined;
+  export type UseRequestHook<T> = (queryConfig: QueryConfig<T>) => [QueryState, ForceRequestCallback<T>];
+  export type MutationQueryConfigFactory<T> = (...args: any) => QueryConfig<T>;
+  export type RunMutation<T> = (...args: any) => Promise<ActionPromiseValue<T>>;
+  export type UseMutationHook<T> = (
+    createQueryConfig: MutationQueryConfigFactory<T>,
+  ) => [QueryState, RunMutation<T>];
 
   export const connectRequest: RequestConnector;
   export const Provider: ReduxQueryProvider;

--- a/packages/redux-query-react/index.d.ts
+++ b/packages/redux-query-react/index.d.ts
@@ -2,32 +2,33 @@ declare module 'redux-query-react' {
   import React from 'react';
   import {
     ActionPromiseValue,
+    Entities,
     QueriesState,
     QueryConfig,
     QueryState,
     QueriesSelector,
   } from 'redux-query';
 
-  export type QueryConfigFactory<T> = (...args: any[]) => QueryConfig<T>;
-  export type QueryConfigsFactory<T> = (...args: any[]) => QueryConfig<T> | QueryConfig<T>[];
+  export type QueryConfigFactory<TEntities> = (...args: any[]) => QueryConfig<TEntities>;
+  export type QueryConfigsFactory<TEntities> = (...args: any[]) => QueryConfig<TEntities> | QueryConfig<TEntities>[];
 
   export interface ConnectRequestOptions {
     forwardRef?: boolean;
     pure?: boolean;
   }
-  export type ForceRequestCallback<T> = () => Promise<ActionPromiseValue<T>>;
-  export interface WithForceRequest<T> {
-    forceRequest: ForceRequestCallback<T>;
+  export type ForceRequestCallback<TEntities> = () => Promise<ActionPromiseValue<TEntities>>;
+  export interface WithForceRequest<TEntities> {
+    forceRequest: ForceRequestCallback<TEntities>;
   }
 
-  export type ConnectRequestWrapper<TProps extends WithForceRequest> = (
+  export type ConnectRequestWrapper<TProps extends WithForceRequest<any>> = (
     WrappedComponent: React.ComponentType<TProps>,
   ) => React.ComponentType<Omit<TProps, 'forceRequest'>>;
 
-  export type RequestConnector = <TState, TProps extends WithForceRequest = WithForceRequest>(
-    mapPropsToConfigs: QueryConfigsFactory<TState>,
+  export type RequestConnector = <TProps extends WithForceRequest<TEntities> = WithForceRequest<TEntities>, TEntities = Entities>(
+    mapPropsToConfigs: QueryConfigsFactory<TEntities>,
     options?: ConnectRequestOptions,
-  ) => ConnectRequestWrapper<TProps>;
+  ) => ConnectRequestWrapper<TProps, TEntities>;
 
   export interface ProviderProps {
     queriesSelector: QueriesSelector;
@@ -35,13 +36,13 @@ declare module 'redux-query-react' {
   }
 
   export type ReduxQueryProvider = React.ComponentType<ProviderProps>;
-  export type ActionPromise<T> = Promise<ActionPromiseValue<T>> | undefined;
-  export type UseRequestHook<T> = (queryConfig: QueryConfig<T>) => [QueryState, ForceRequestCallback<T>];
-  export type MutationQueryConfigFactory<T> = (...args: any) => QueryConfig<T>;
-  export type RunMutation<T> = (...args: any) => Promise<ActionPromiseValue<T>>;
-  export type UseMutationHook<T> = (
-    createQueryConfig: MutationQueryConfigFactory<T>,
-  ) => [QueryState, RunMutation<T>];
+  export type ActionPromise<TEntities> = Promise<ActionPromiseValue<TEntities>> | undefined;
+  export type UseRequestHook = <TEntities>(queryConfig: QueryConfig<TEntities>) => [QueryState, ForceRequestCallback<TEntities>];
+  export type MutationQueryConfigFactory = <TEntities>(...args: any) => QueryConfig<TEntities>;
+  export type RunMutation = <TEntities>(...args: any) => Promise<ActionPromiseValue<TEntities>>;
+  export type UseMutationHook = <TEntities>(
+    createQueryConfig: MutationQueryConfigFactory<TEntities>,
+  ) => [QueryState, RunMutation<TEntities>];
 
   export const connectRequest: RequestConnector;
   export const Provider: ReduxQueryProvider;

--- a/packages/redux-query/index.d.ts
+++ b/packages/redux-query/index.d.ts
@@ -7,7 +7,7 @@ declare module 'redux-query' {
   export interface RequestHeaders {
     [key: string]: RequestHeader;
   }
-  export type MetaValue = string;
+  export type MetaValue = any;
   export interface Meta {
     [key: string]: MetaValue;
   }

--- a/packages/redux-query/index.d.ts
+++ b/packages/redux-query/index.d.ts
@@ -29,7 +29,7 @@ declare module 'redux-query' {
   export type TransformStrategy<Entities> = (
     body: ResponseBody,
     text: ResponseText,
-  ) => Entities;
+  ) => Partial<Entities>;
   export type UpdateStrategy<T> = (prevValue: T, newValue: T) => T;
   export type OptimisticUpdateStrategy<T> = (prevValue: T) => T;
   export type RollbackStrategy<T> = (initialValue: T, currentValue: T) => T;

--- a/packages/redux-query/index.d.ts
+++ b/packages/redux-query/index.d.ts
@@ -20,30 +20,34 @@ declare module 'redux-query' {
   }
   export type ResponseStatus = number;
   export type Duration = number;
+  export interface Entities {
+    [key: string]: any;
+  }
+  export type EntitiesState = Entities;
 
   export type KnownHttpMethods = 'GET' | 'PUT' | 'POST' | 'DELETE' | 'PATCH' | 'OPTIONS';
   export type HttpMethods = KnownHttpMethods | string;
 
   export const httpMethods: { [k in KnownHttpMethods]: KnownHttpMethods };
 
-  export type TransformStrategy<Entities, Body = ResponseBody> = (
-    body: Body,
+  export type TransformStrategy<TEntities = Entities, TBody = ResponseBody> = (
+    body: TBody,
     text: ResponseText,
-  ) => Partial<Entities>;
+  ) => Partial<TEntities>;
   export type UpdateStrategy<T> = (prevValue: T, newValue: T) => T;
   export type OptimisticUpdateStrategy<T> = (prevValue: T) => T;
   export type RollbackStrategy<T> = (initialValue: T, currentValue: T) => T;
 
-  export type Update<Entities> = {
-    [K in keyof Entities]?: UpdateStrategy<Entities[K]>;
+  export type Update<TEntities = Entities> = {
+    [K in keyof TEntities]?: UpdateStrategy<TEntities[K]>;
   }
 
-  export type OptimisticUpdate<Entities> = {
-    [K in keyof Entities]?: OptimisticUpdateStrategy<Entities[K]>;
+  export type OptimisticUpdate<TEntities = Entities> = {
+    [K in keyof TEntities]?: OptimisticUpdateStrategy<TEntities[K]>;
   }
 
-  export type Rollback<Entities> = {
-    [K in keyof Entities]?: RollbackStrategy<Entities[K]>;
+  export type Rollback<TEntities = Entities> = {
+    [K in keyof TEntities]?: RollbackStrategy<TEntities[K]>;
   }
 
   export interface WithTime {
@@ -54,11 +58,11 @@ declare module 'redux-query' {
     queryKey: QueryKey;
   }
 
-  export interface WithUpdateEntities<Entities> {
-    update: Update<Entities>;
+  export interface WithUpdateEntities<TEntities = Entities> {
+    update: Update<TEntities>;
   }
 
-  export type RequestAsyncAction<Entities> = Action<'@@query/REQUEST_ASYNC'> & QueryConfig<Entities>;
+  export type RequestAsyncAction<TEntities = Entities> = Action<'@@query/REQUEST_ASYNC'> & QueryConfig<TEntities>;
 
   export interface QueryStartParams {
     body?: RequestBody;
@@ -66,15 +70,15 @@ declare module 'redux-query' {
     queryKey: QueryKey;
     url: Url;
   }
-  export interface WithOptimisticEntities<Entities> {
-    optimisticEntities: Entities;
+  export interface WithOptimisticEntities<TEntities = Entities> {
+    optimisticEntities: TEntities;
   }
   export type MutateStartParams = QueryStartParams;
   export type RequestStartAction = Action<'@@query/REQUEST_START'> & QueryStartParams;
-  export interface QueryResponse<Entities> {
+  export interface QueryResponse<TEntities = Entities> {
     body: RequestBody;
     duration: Duration;
-    entities: Entities;
+    entities: TEntities;
     meta?: Meta;
     responseBody?: ResponseBody;
     responseHeaders?: ResponseHeaders;
@@ -84,16 +88,16 @@ declare module 'redux-query' {
     url: Url;
   }
 
-  export type RequestSuccessAction<Entities> = Action<'@@query/REQUEST_SUCCESS'> | QueryResponse<Entities> | WithTime;
-  export type RequestFailureAction<Entities> = Action<'@@query/REQUEST_FAILURE'> | QueryResponse<Entities> | WithTime;
-  export type MutateAsyncAction<Entities> = Action<'@@query/MUTATE_ASYNC'> & QueryConfig<Entities>;
+  export type RequestSuccessAction<TEntities = Entities> = Action<'@@query/REQUEST_SUCCESS'> | QueryResponse<TEntities> | WithTime;
+  export type RequestFailureAction<TEntities = Entities> = Action<'@@query/REQUEST_FAILURE'> | QueryResponse<TEntities> | WithTime;
+  export type MutateAsyncAction<TEntities = Entities> = Action<'@@query/MUTATE_ASYNC'> & QueryConfig<TEntities>;
   export type MutateSuccessAction = Action<'@@query/MUTATE_SUCCESS'> & QueryResponse;
-  export type UpdateEntitiesAction<Entities> = Action<'@@query/UPDATE_ENTITIES'> & WithUpdateEntities<Entities>;
+  export type UpdateEntitiesAction<TEntities = Entities> = Action<'@@query/UPDATE_ENTITIES'> & WithUpdateEntities<TEntities>;
   export type CancelQueryAction = Action<'@@query/CANCEL_QUERY'> & WithQueryKey;
-  export type ReduxQueryAction<Entities> =
-    | RequestAsyncAction<Entities>
-    | MutateAsyncAction<Entities>
-    | UpdateEntitiesAction<Entities>
+  export type ReduxQueryAction<TEntities = Entities> =
+    | RequestAsyncAction<TEntities>
+    | MutateAsyncAction<TEntities>
+    | UpdateEntitiesAction<TEntities>
     | CancelQueryAction;
 
   export const requestAsync: <T>(params: QueryConfig<T>) => RequestAsyncAction<T>;
@@ -132,17 +136,17 @@ declare module 'redux-query' {
     headers?: { [key: string]: string };
   }
 
-  export interface QueryConfig<Entities> {
+  export interface QueryConfig<TEntities = Entities> {
     body?: RequestBody;
     force?: boolean;
     meta?: Meta;
     options?: QueryOptions;
     queryKey?: QueryKey;
-    transform?: TransformStrategy<Entities>;
-    update?: Update<Entities>;
-    optimisticUpdate?: OptimisticUpdate<Entities>;
+    transform?: TransformStrategy<TEntities>;
+    update?: Update<TEntities>;
+    optimisticUpdate?: OptimisticUpdate<TEntities>;
     retry?: boolean;
-    rollback?: Rollback<Entities>;
+    rollback?: Rollback<TEntities>;
     unstable_preDispatchCallback?: () => void;
     url: Url;
   }
@@ -160,11 +164,11 @@ declare module 'redux-query' {
     };
   }
 
-  export type QueriesSelector = (state: any) => QueriesState;
+  export type QueriesSelector<TState = any> = (state: TState) => QueriesState;
 
-  export type EntitiesSelector<EntitiesState, State = any> = (state: State) => EntitiesState;
+  export type EntitiesSelector<TEntities = EntitiesState, TState = any> = (state: TState) => TEntities;
 
-  export type QueryKeyBuilder<Entities> = (queryConfig?: QueryConfig<Entities>) => QueryKey | undefined;
+  export type QueryKeyBuilder<TEntities = Entities> = (queryConfig?: QueryConfig<TEntities>) => QueryKey | undefined;
 
   export interface QueryState {
     headers?: ResponseHeaders;
@@ -175,14 +179,14 @@ declare module 'redux-query' {
     status?: ResponseStatus;
   }
 
-  export interface ActionPromiseValue<Entities> {
+  export interface ActionPromiseValue<TEntities = Entities> {
     body: ResponseBody;
     duration: Duration;
-    entities?: Entities;
+    entities?: TEntities;
     headers?: ResponseHeaders;
     status: ResponseStatus;
     text?: ResponseText;
-    transformed?: Entities;
+    transformed?: TEntities;
   }
 
   export interface ErrorsState {
@@ -200,13 +204,13 @@ declare module 'redux-query' {
     };
     retryableStatusCodes: ResponseStatus[];
   }
-  export type QueriesReducer = Reducer<QueriesState, ReduxQueryAction>;
-  export type EntitiesReducer<EntitiesState> = Reducer<EntitiesState, ReduxQueryAction>;
-  export type ErrorsReducer = Reducer<ErrorsState, ReduxQueryAction>;
-  export type QueryMiddlewareFactory = (
+  export type QueriesReducer<TEntities = EntitiesState> = Reducer<QueriesState, ReduxQueryAction<TEntities>>;
+  export type EntitiesReducer<TEntities = EntitiesState> = Reducer<TEntities, ReduxQueryAction<TEntities>>;
+  export type ErrorsReducer<TEntities = EntitiesState> = Reducer<ErrorsState, ReduxQueryAction<TEntities>>;
+  export type QueryMiddlewareFactory = <TEntities = EntitiesState, TState = any>(
     networkInterface: NetworkInterface,
-    queriesSelector: QueriesSelector,
-    entitiesSelector: EntitiesSelector,
+    queriesSelector: QueriesSelector<TState>,
+    entitiesSelector: EntitiesSelector<TEntities, TState>,
     customConfig?: Config,
   ) => Middleware<ReduxQueryDispatch, any, ReduxQueryDispatch>;
   export const getQueryKey: QueryKeyBuilder;
@@ -243,8 +247,8 @@ declare module 'redux-query' {
   };
 
   export const queryMiddleware: QueryMiddlewareFactory;
-  export interface ReduxQueryDispatch<A extends AnyAction = ReduxQueryAction> {
-    <T extends ReduxQueryAction>(action: ReduxQueryAction): Promise<ActionPromiseValue>;
+  export interface ReduxQueryDispatch<A extends AnyAction = ReduxQueryAction<TEntities>, TEntities = Entities> {
+    <T extends ReduxQueryAction<TEntities>>(action: ReduxQueryAction<TEntities>): Promise<ActionPromiseValue<TEntities>>;
     <T extends A>(action: T): T;
   }
 }

--- a/packages/redux-query/index.d.ts
+++ b/packages/redux-query/index.d.ts
@@ -26,8 +26,8 @@ declare module 'redux-query' {
 
   export const httpMethods: { [k in KnownHttpMethods]: KnownHttpMethods };
 
-  export type TransformStrategy<Entities> = (
-    body: ResponseBody,
+  export type TransformStrategy<Entities, Body = ResponseBody> = (
+    body: Body,
     text: ResponseText,
   ) => Partial<Entities>;
   export type UpdateStrategy<T> = (prevValue: T, newValue: T) => T;

--- a/packages/redux-query/index.d.ts
+++ b/packages/redux-query/index.d.ts
@@ -25,7 +25,14 @@ declare module 'redux-query' {
   }
   export type EntitiesState = Entities;
 
-  export type KnownHttpMethods = 'GET' | 'PUT' | 'POST' | 'DELETE' | 'PATCH' | 'OPTIONS';
+  export type KnownHttpMethods =
+    | 'GET'
+    | 'HEAD'
+    | 'PUT'
+    | 'POST'
+    | 'DELETE'
+    | 'PATCH'
+    | 'OPTIONS';
   export type HttpMethods = KnownHttpMethods | string;
 
   export const httpMethods: { [k in KnownHttpMethods]: KnownHttpMethods };


### PR DESCRIPTION
As our team was exploring integrating redux-query into a new project using TS + React, we discovered the the built in type definitions in redux-query define the "entities state" very loosely, i.e. `type Entities = { [key: string]: any }` which really doesn't provide any time safety for the individual parts of the entities collection.

This PR is my first pass at making most of the types generic in `T`, where `T` is the type of "entities" defined for your particular usage.

With this PR, you might end up w/ something like:

```
interface Notification {
  id: string;
  name: string;
}

interface EntitiesState {
  notificationsById: { [key: string]: Notification }
}
```

And then your *application state*, would be:

```
interface State {
  entities: EntitiesState;
  queries: QueriesState;
}
```

With these changes, we can also strongly type the `update`, and `transform` props in the query config too, so those are strongly typed, including `update` only allowing callbacks that actually map to a property name in your `EntitiesState` and asserting the types parameter types for those callbacks matches, etc.

One thing I *didn't* do in this PR was any attempt at *defaulting* the generic `Entities` type parameter back to the original `interface Entities { [key: string]: any }` like it was *before* this PR.

Theoretically, if you do some defaulting of that type parameter, this is at least *more* backwards compatible. I am happy to pursue that if the maintainer(s) are interested in this general approach.

Thoughts?