### PR TITLE
Use requests PR

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.3.0
+
+- New React hook - `useRequests` (rctbusk [#159](https://github.com/amplitude/redux-query/pull/159))
+
 ## 3.2.1
 
 - Generic Entities Typing Fix (petejohanson [#155](https://github.com/amplitude/redux-query/pull/155))

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ A library for managing network state in Redux.
 ## React API
 
 - [useRequest](https://amplitude.github.io/redux-query/docs/use-request)
+- [useRequests](https://amplitude.github.io/redux-query/docs/use-requests)
 - [useMutation](https://amplitude.github.io/redux-query/docs/use-mutation)
 - [connectRequest](https://amplitude.github.io/redux-query/docs/connect-request)
 

--- a/docs/examples/hacker-news.md
+++ b/docs/examples/hacker-news.md
@@ -5,7 +5,7 @@ title: Hacker News
 
 This example shows how to use redux-query, redux-query-react, and redux-query-interface-superagent to build a basic Hacker News client. You can run this example in the browser by clicking the button below:
 
-[![Edit redux-query Hacker News Example](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/redux-query-hacker-news-example-qkwzo?fontsize=14)
+[![Edit redux-query Hacker News Example](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/trusting-wilson-ndyzf?fontsize=14)
 
 ## Entry point
 
@@ -67,22 +67,6 @@ export const topStoriesRequest = () => {
   };
 };
 
-export const newStoriesRequest = () => {
-  return {
-    url: `https://hacker-news.firebaseio.com/v0/newstories.json`,
-    transform: body => ({
-      // The server responds with an array of IDs
-      newStoryIds: body,
-    }),
-    update: {
-      newStoryIds: (prev, next) => {
-        // Discard previous `response` value (we don't need it anymore).
-        return next;
-      },
-    },
-  };
-};
-
 export const itemRequest = itemId => {
   return {
     url: `https://hacker-news.firebaseio.com/v0/item/${itemId}.json`,
@@ -113,10 +97,6 @@ const emptyArray = [];
 
 export const getTopStoryIds = state => {
   return state.entities.topStoryIds || emptyArray;
-};
-
-export const getNewStoryIds = state => {
-  return state.entities.newStoryIds || emptyArray;
 };
 
 export const getItem = (state, itemId) => {
@@ -180,50 +160,20 @@ import Item from '../components/Item';
 import * as storyQueryConfigs from '../query-configs/stories';
 import * as storySelectors from '../selectors/stories';
 
-const Stories = props => {
-  const [{ isPending }] = useRequests([
-    storyQueryConfigs.topStoriesRequest(),
-    storyQueryConfigs.newStoriesRequest(),
-  ]);
+const TopStories = props => {
+  useRequest(storyQueryConfigs.topStoriesRequest());
   const topStoryIds = useSelector(storySelectors.getTopStoryIds);
-  const newStoryIds = useSelector(storySelectors.getNewStoryIds);
-
-  const [listToShow, setListToShow] = React.useState('new');
-
-  if (isPending) {
-    return 'Loading';
-  }
 
   return (
-    <div>
-      <div style={{ display: 'flex', cursor: 'pointer', color: 'blue', fontSize: '20px' }}>
-        <div
-          style={{ paddingRight: '10px', textDecoration: 'underline' }}
-          onClick={() => {
-            setListToShow('new');
-          }}
-        >
-          New
-        </div>
-        <div
-          style={{ paddingRight: '10px', textDecoration: 'underline' }}
-          onClick={() => {
-            setListToShow('top');
-          }}
-        >
-          Top
-        </div>
-      </div>
-      <ol>
-        {(listToShow === 'top' ? topStoryIds : newStoryIds).slice(0, 30).map(itemId => (
-          <Item itemId={itemId} key={itemId} />
-        ))}
-      </ol>
-    </div>
+    <ol>
+      {topStoryIds.slice(0, 30).map(itemId => (
+        <Item itemId={itemId} key={itemId} />
+      ))}
+    </ol>
   );
 };
 
-export default Stories;
+export default TopStories;
 ```
 
 ### `components/HackerNews.js`
@@ -233,7 +183,7 @@ import * as React from 'react';
 import { Provider } from 'react-redux';
 import { Provider as ReduxQueryProvider } from 'redux-query-react';
 
-import Stories from '../components/Stories';
+import TopStories from '../components/TopStories';
 import { getQueries } from '../store';
 
 const HackerNews = props => {
@@ -242,7 +192,7 @@ const HackerNews = props => {
       <ReduxQueryProvider queriesSelector={getQueries}>
         <>
           <h1>Hacker News</h1>
-          <Stories />
+          <TopStories />
         </>
       </ReduxQueryProvider>
     </Provider>

--- a/docs/examples/simple.md
+++ b/docs/examples/simple.md
@@ -5,7 +5,7 @@ title: Simple Example
 
 This example is a very simple web app that has only one feature – you can view and update your username. The purpose of this example is to demonstrate how requests and mutations (including optimistic updates) work with redux-query.
 
-[![Edit redux-query Basic Example](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/redux-query-hacker-news-example-jpoko?fontsize=14)
+[![Edit redux-query Basic Example](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/redux-query-basic-example-8x4zo?fontsize=14)
 
 **Note**: This example fakes a server with a custom mock [network interface](../network-interfaces). In a real app, you would want to use a network interface that actually communicates to a server via HTTP.
 

--- a/docs/redux-actions.md
+++ b/docs/redux-actions.md
@@ -52,7 +52,7 @@ Similarly to how mutations are triggered by dispatching `mutateAsync` actions, y
 
 You can also Promise-chain on dispatched `requestAsync` actions, but a Promise will only be returned if `redux-query` determines it will make a network request. For example, if the query config does not have `force` set to `true` and a previous request with the same query key previously succeeded, then a Promise will not be returned. So be sure to always check that the returned value from a dispatched `requestAsync` is a Promise before interacting with it.
 
-**Note**: With redux-query-react, [`connectRequest`](connect-request) and [`useRequest`](use-request) automatically dispatch `requestAsync` actions when the associated component mounts (if the provided query config is valid). It will also dispatch `requestAsync` actions whenever the query config updates with a new query key.
+**Note**: With redux-query-react, [`connectRequest`](connect-request), [`useRequest`](use-request), and [`useRequests`](use-requests) automatically dispatch `requestAsync` actions when the associated component mounts (if the provided query config is valid). It will also dispatch `requestAsync` actions whenever the query config updates with a new query key.
 
 ## cancelQuery
 
@@ -66,7 +66,7 @@ import { cancelQuery } from 'redux-query';
 store.dispatch(cancelQuery('{"url":"/api/playlists"}'));
 ```
 
-**Note**: With redux-query-react, [`connectRequest`](connect-request) and [`useRequest`](use-request) automatically dispatch `cancelQuery` actions when the associated component unmounts.
+**Note**: With redux-query-react, [`connectRequest`](connect-request), [`useRequest`](use-request), and [`useRequests`](use-requests) automatically dispatch `cancelQuery` actions when the associated component unmounts.
 
 ## updateEntities
 

--- a/docs/requests-vs-mutations.md
+++ b/docs/requests-vs-mutations.md
@@ -18,7 +18,7 @@ Mutations always trigger a network request.
 
 Dispatch a [requestAsync](redux-actions#requestasync) action with your Redux store.
 
-If you'd like to make a request right from a React component, install redux-query-react and use either the [useRequest](use-request) hooks or the [connectRequest](connect-request) HOC.
+If you'd like to make a request right from a React component, install redux-query-react and use either the [useRequest](use-request) and [`useRequests`](use-requests) hooks or the [connectRequest](connect-request) HOC.
 
 ## How to make mutations
 

--- a/docs/upgrade-guides/v2-to-v3.md
+++ b/docs/upgrade-guides/v2-to-v3.md
@@ -53,7 +53,7 @@ If your app uses connectRequest:
 2. Add redux-query-react as a dependency.
 3. Follow the [getting started](getting-started#setup-react-integration) section for setting up the React integration.
 4. If any of your existing connectRequest calls use the `withRef` configuration option, rename that to `forwardRef`.
-5. Going forwards, consider using [useRequest](../use-request) and [useMutation]('../use-mutation) instead of connectRequest for new components.
+5. Going forwards, consider using [useRequest](../use-request), [useRequests](../use-requests), and [useMutation]('../use-mutation) instead of connectRequest for new components.
 
 And finally:
 

--- a/docs/use-requests.md
+++ b/docs/use-requests.md
@@ -1,0 +1,70 @@
+---
+id: use-requests
+title: useRequestss
+---
+
+`useRequests` is one of the React hooks provided by redux-query-react. It's intended to be used for cases when you have a component that has network dependencies (i.e. things need to load from the server in order for this component to render properly). Its behavior is as follows:
+
+1. When the associated component first renders, if there is a valid array of query configs provided, then requests will be made (by dispatching a [`requestAsync`](redux-actions#requestasync) action).
+2. Whenever the query configs change and its query keys also change as a result, then new requests will be made. Also, if there are previously-issued requests that is still in-flight, then a [`cancelQuery`](redux-actions#cancelquery) action will be dispatched which will attempt to abort the active network requests.
+3. When the associated component unmounts and there are requests in-flight, then [`cancelQuery`](redux-actions#cancelquery) actions will be dispatched which will attempt to abort the active network requests.
+
+## API
+
+`useRequests` takes a single parameter – an array of query configs. If you pass null, undefined, or an invalid array of query configs as the parameter to `useRequests`, the values will be ignored.
+
+`useRequests` returns a tuple-like array, where the first value in the tuple is an object representing the state of the requests. This object will have "isFinished" and "isPending" keys. "isFinished" will be false until all queries in the query array are cmopleted. "isPending" will be true as long as any of the queries are still in flight. The second value in the tuple is a callback to re-issue all the requests, even if previous requests with the same query key have already been made and resulted in a successful server responses.
+
+## Example
+
+```javascript
+import * as React from 'react';
+import { useSelector } from 'react-redux';
+import { useRequests } from 'redux-query-react';
+
+const getNotifications = state => state.entities.notifications;
+
+const getUsers = state => state.entities.users;
+
+const requests = [
+  {
+    url: '/api/notifications',
+    update: {
+      notifications: (oldValue, newValue) => newValue,
+    },
+  },
+  {
+    url: '/api/users',
+    update: {
+      users: (oldValue, newValue) => newValue,
+    },
+  },
+];
+
+const NotificationsView = () => {
+  const notifications = useSelector(getNotifications) || [];
+  const users = useSelector(getUsers) || [];
+
+  const [{ isPending, isFinished }, refresh] = useRequests(requests);
+
+  if (isPending) {
+    return 'Loading…';
+  }
+
+  return (
+    <div>
+      <button onClick={refresh}>Refresh</button>
+      <ul>
+        {notifications.map(notification => (
+          <Notification key={notificationId} />
+        ))}
+      </ul>
+      <ul>
+        {users.map(user => (
+          <User key={userId} />
+        ))}
+      </ul>
+    </div>
+  );
+};
+```

--- a/docs/use-requests.md
+++ b/docs/use-requests.md
@@ -1,6 +1,6 @@
 ---
 id: use-requests
-title: useRequestss
+title: useRequests
 ---
 
 `useRequests` is one of the React hooks provided by redux-query-react. It's intended to be used for cases when you have a component that has network dependencies (i.e. things need to load from the server in order for this component to render properly). Its behavior is as follows:

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
   "packages": ["packages/*", "site"],
-  "version": "3.3.0-alpha.4",
+  "version": "3.3.0-alpha.5",
   "npmClient": "yarn"
 }

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
   "packages": ["packages/*", "site"],
-  "version": "3.3.0-rc.0",
+  "version": "3.3.0",
   "npmClient": "yarn"
 }

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
   "packages": ["packages/*", "site"],
-  "version": "3.3.0-alpha.2",
+  "version": "3.3.0-alpha.3",
   "npmClient": "yarn"
 }

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
   "packages": ["packages/*", "site"],
-  "version": "3.2.1",
+  "version": "3.3.0-alpha.0",
   "npmClient": "yarn"
 }

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
   "packages": ["packages/*", "site"],
-  "version": "3.3.0-alpha.5",
+  "version": "3.3.0-alpha.6",
   "npmClient": "yarn"
 }

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
   "packages": ["packages/*", "site"],
-  "version": "3.3.0-alpha.3",
+  "version": "3.3.0-alpha.4",
   "npmClient": "yarn"
 }

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
   "packages": ["packages/*", "site"],
-  "version": "3.3.0-alpha.6",
+  "version": "3.3.0-alpha.7",
   "npmClient": "yarn"
 }

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
   "packages": ["packages/*", "site"],
-  "version": "3.3.0-alpha.0",
+  "version": "3.3.0-alpha.1",
   "npmClient": "yarn"
 }

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
   "packages": ["packages/*", "site"],
-  "version": "3.3.0-alpha.1",
+  "version": "3.3.0-alpha.2",
   "npmClient": "yarn"
 }

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
   "packages": ["packages/*", "site"],
-  "version": "3.3.0-alpha.7",
+  "version": "3.3.0-rc.0",
   "npmClient": "yarn"
 }

--- a/packages/redux-query-interface-superagent/package.json
+++ b/packages/redux-query-interface-superagent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "redux-query-interface-superagent",
-  "version": "3.3.0-alpha.4",
+  "version": "3.3.0-alpha.5",
   "description": "The default interface for redux-query, powered by superagent",
   "homepage": "https://github.com/amplitude/redux-query",
   "main": "dist/commonjs/index.js",
@@ -49,7 +49,7 @@
     "eslint": "^5.11.1",
     "eslint-plugin-import": "^2.14.0",
     "jest": "^24.8.0",
-    "redux-query": "^3.3.0-alpha.4",
+    "redux-query": "^3.3.0-alpha.5",
     "rimraf": "^2.4.3",
     "superagent-mock": "^3.7.0",
     "terser-webpack-plugin": "^1.3.0",

--- a/packages/redux-query-interface-superagent/package.json
+++ b/packages/redux-query-interface-superagent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "redux-query-interface-superagent",
-  "version": "3.3.0-alpha.3",
+  "version": "3.3.0-alpha.4",
   "description": "The default interface for redux-query, powered by superagent",
   "homepage": "https://github.com/amplitude/redux-query",
   "main": "dist/commonjs/index.js",
@@ -49,7 +49,7 @@
     "eslint": "^5.11.1",
     "eslint-plugin-import": "^2.14.0",
     "jest": "^24.8.0",
-    "redux-query": "^3.3.0-alpha.3",
+    "redux-query": "^3.3.0-alpha.4",
     "rimraf": "^2.4.3",
     "superagent-mock": "^3.7.0",
     "terser-webpack-plugin": "^1.3.0",

--- a/packages/redux-query-interface-superagent/package.json
+++ b/packages/redux-query-interface-superagent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "redux-query-interface-superagent",
-  "version": "3.3.0-alpha.6",
+  "version": "3.3.0-rc.0",
   "description": "The default interface for redux-query, powered by superagent",
   "homepage": "https://github.com/amplitude/redux-query",
   "main": "dist/commonjs/index.js",
@@ -49,7 +49,7 @@
     "eslint": "^5.11.1",
     "eslint-plugin-import": "^2.14.0",
     "jest": "^24.8.0",
-    "redux-query": "^3.3.0-alpha.6",
+    "redux-query": "^3.3.0-rc.0",
     "rimraf": "^2.4.3",
     "superagent-mock": "^3.7.0",
     "terser-webpack-plugin": "^1.3.0",

--- a/packages/redux-query-interface-superagent/package.json
+++ b/packages/redux-query-interface-superagent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "redux-query-interface-superagent",
-  "version": "3.3.0-rc.0",
+  "version": "3.3.0",
   "description": "The default interface for redux-query, powered by superagent",
   "homepage": "https://github.com/amplitude/redux-query",
   "main": "dist/commonjs/index.js",
@@ -49,7 +49,7 @@
     "eslint": "^5.11.1",
     "eslint-plugin-import": "^2.14.0",
     "jest": "^24.8.0",
-    "redux-query": "^3.3.0-rc.0",
+    "redux-query": "^3.3.0",
     "rimraf": "^2.4.3",
     "superagent-mock": "^3.7.0",
     "terser-webpack-plugin": "^1.3.0",

--- a/packages/redux-query-interface-superagent/package.json
+++ b/packages/redux-query-interface-superagent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "redux-query-interface-superagent",
-  "version": "3.2.1",
+  "version": "3.3.0-alpha.1",
   "description": "The default interface for redux-query, powered by superagent",
   "homepage": "https://github.com/amplitude/redux-query",
   "main": "dist/commonjs/index.js",
@@ -49,7 +49,7 @@
     "eslint": "^5.11.1",
     "eslint-plugin-import": "^2.14.0",
     "jest": "^24.8.0",
-    "redux-query": "^3.2.1",
+    "redux-query": "^3.3.0-alpha.1",
     "rimraf": "^2.4.3",
     "superagent-mock": "^3.7.0",
     "terser-webpack-plugin": "^1.3.0",

--- a/packages/redux-query-interface-superagent/package.json
+++ b/packages/redux-query-interface-superagent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "redux-query-interface-superagent",
-  "version": "3.3.0-alpha.5",
+  "version": "3.3.0-alpha.6",
   "description": "The default interface for redux-query, powered by superagent",
   "homepage": "https://github.com/amplitude/redux-query",
   "main": "dist/commonjs/index.js",
@@ -49,7 +49,7 @@
     "eslint": "^5.11.1",
     "eslint-plugin-import": "^2.14.0",
     "jest": "^24.8.0",
-    "redux-query": "^3.3.0-alpha.5",
+    "redux-query": "^3.3.0-alpha.6",
     "rimraf": "^2.4.3",
     "superagent-mock": "^3.7.0",
     "terser-webpack-plugin": "^1.3.0",

--- a/packages/redux-query-interface-superagent/package.json
+++ b/packages/redux-query-interface-superagent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "redux-query-interface-superagent",
-  "version": "3.3.0-alpha.2",
+  "version": "3.3.0-alpha.3",
   "description": "The default interface for redux-query, powered by superagent",
   "homepage": "https://github.com/amplitude/redux-query",
   "main": "dist/commonjs/index.js",
@@ -49,7 +49,7 @@
     "eslint": "^5.11.1",
     "eslint-plugin-import": "^2.14.0",
     "jest": "^24.8.0",
-    "redux-query": "^3.3.0-alpha.2",
+    "redux-query": "^3.3.0-alpha.3",
     "rimraf": "^2.4.3",
     "superagent-mock": "^3.7.0",
     "terser-webpack-plugin": "^1.3.0",

--- a/packages/redux-query-interface-superagent/package.json
+++ b/packages/redux-query-interface-superagent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "redux-query-interface-superagent",
-  "version": "3.3.0-alpha.1",
+  "version": "3.3.0-alpha.2",
   "description": "The default interface for redux-query, powered by superagent",
   "homepage": "https://github.com/amplitude/redux-query",
   "main": "dist/commonjs/index.js",
@@ -49,7 +49,7 @@
     "eslint": "^5.11.1",
     "eslint-plugin-import": "^2.14.0",
     "jest": "^24.8.0",
-    "redux-query": "^3.3.0-alpha.1",
+    "redux-query": "^3.3.0-alpha.2",
     "rimraf": "^2.4.3",
     "superagent-mock": "^3.7.0",
     "terser-webpack-plugin": "^1.3.0",

--- a/packages/redux-query-react/README.md
+++ b/packages/redux-query-react/README.md
@@ -17,6 +17,7 @@ redux-query-react is a library for directly integrating [redux-query](https://am
 ## API
 
 - [useRequest](https://amplitude.github.io/redux-query/docs/use-request)
+- [useRequests](https://amplitude.github.io/redux-query/docs/use-requests)
 - [useMutation](https://amplitude.github.io/redux-query/docs/use-mutation)
 - [connectRequest](https://amplitude.github.io/redux-query/docs/connect-request)
 

--- a/packages/redux-query-react/flow-test/hooks/use-requests.js
+++ b/packages/redux-query-react/flow-test/hooks/use-requests.js
@@ -1,0 +1,20 @@
+// @flow
+
+import * as React from 'react';
+
+import useRequest from '../../src/hooks/use-requests';
+
+const Card = () => {
+  const [{ isPending }] = useRequest([
+    {
+      url: '/api',
+    },
+    { url: '/test' },
+  ]);
+
+  return <div>{isPending ? 'loading…' : 'loaded'}</div>;
+};
+
+export const App = () => {
+  return <Card />;
+};

--- a/packages/redux-query-react/package.json
+++ b/packages/redux-query-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "redux-query-react",
-  "version": "3.3.0-alpha.3",
+  "version": "3.3.0-alpha.4",
   "description": "The React interface for integrating with redux-query",
   "homepage": "https://github.com/amplitude/redux-query",
   "main": "dist/commonjs/index.js",
@@ -68,7 +68,7 @@
     "react-redux": "7.1.0",
     "react-test-renderer": "^16.8.6",
     "redux": "^4.0.1",
-    "redux-query": "^3.3.0-alpha.3",
+    "redux-query": "^3.3.0-alpha.4",
     "rimraf": "^2.4.3",
     "terser-webpack-plugin": "^1.3.0",
     "webpack": "^4.19.0",

--- a/packages/redux-query-react/package.json
+++ b/packages/redux-query-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "redux-query-react",
-  "version": "3.3.0-alpha.7",
+  "version": "3.3.0-rc.0",
   "description": "The React interface for integrating with redux-query",
   "homepage": "https://github.com/amplitude/redux-query",
   "main": "dist/commonjs/index.js",
@@ -68,7 +68,7 @@
     "react-redux": "7.1.0",
     "react-test-renderer": "^16.8.6",
     "redux": "^4.0.1",
-    "redux-query": "^3.3.0-alpha.6",
+    "redux-query": "^3.3.0-rc.0",
     "rimraf": "^2.4.3",
     "terser-webpack-plugin": "^1.3.0",
     "webpack": "^4.19.0",

--- a/packages/redux-query-react/package.json
+++ b/packages/redux-query-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "redux-query-react",
-  "version": "3.3.0-alpha.6",
+  "version": "3.3.0-alpha.7",
   "description": "The React interface for integrating with redux-query",
   "homepage": "https://github.com/amplitude/redux-query",
   "main": "dist/commonjs/index.js",

--- a/packages/redux-query-react/package.json
+++ b/packages/redux-query-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "redux-query-react",
-  "version": "3.3.0-alpha.4",
+  "version": "3.3.0-alpha.5",
   "description": "The React interface for integrating with redux-query",
   "homepage": "https://github.com/amplitude/redux-query",
   "main": "dist/commonjs/index.js",
@@ -68,7 +68,7 @@
     "react-redux": "7.1.0",
     "react-test-renderer": "^16.8.6",
     "redux": "^4.0.1",
-    "redux-query": "^3.3.0-alpha.4",
+    "redux-query": "^3.3.0-alpha.5",
     "rimraf": "^2.4.3",
     "terser-webpack-plugin": "^1.3.0",
     "webpack": "^4.19.0",

--- a/packages/redux-query-react/package.json
+++ b/packages/redux-query-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "redux-query-react",
-  "version": "3.3.0-rc.0",
+  "version": "3.3.0",
   "description": "The React interface for integrating with redux-query",
   "homepage": "https://github.com/amplitude/redux-query",
   "main": "dist/commonjs/index.js",
@@ -68,7 +68,7 @@
     "react-redux": "7.1.0",
     "react-test-renderer": "^16.8.6",
     "redux": "^4.0.1",
-    "redux-query": "^3.3.0-rc.0",
+    "redux-query": "^3.3.0",
     "rimraf": "^2.4.3",
     "terser-webpack-plugin": "^1.3.0",
     "webpack": "^4.19.0",

--- a/packages/redux-query-react/package.json
+++ b/packages/redux-query-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "redux-query-react",
-  "version": "3.3.0-alpha.0",
+  "version": "3.3.0-alpha.1",
   "description": "The React interface for integrating with redux-query",
   "homepage": "https://github.com/amplitude/redux-query",
   "main": "dist/commonjs/index.js",
@@ -68,7 +68,7 @@
     "react-redux": "7.1.0",
     "react-test-renderer": "^16.8.6",
     "redux": "^4.0.1",
-    "redux-query": "^3.2.1",
+    "redux-query": "^3.3.0-alpha.1",
     "rimraf": "^2.4.3",
     "terser-webpack-plugin": "^1.3.0",
     "webpack": "^4.19.0",

--- a/packages/redux-query-react/package.json
+++ b/packages/redux-query-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "redux-query-react",
-  "version": "3.3.0-alpha.5",
+  "version": "3.3.0-alpha.6",
   "description": "The React interface for integrating with redux-query",
   "homepage": "https://github.com/amplitude/redux-query",
   "main": "dist/commonjs/index.js",
@@ -68,7 +68,7 @@
     "react-redux": "7.1.0",
     "react-test-renderer": "^16.8.6",
     "redux": "^4.0.1",
-    "redux-query": "^3.3.0-alpha.5",
+    "redux-query": "^3.3.0-alpha.6",
     "rimraf": "^2.4.3",
     "terser-webpack-plugin": "^1.3.0",
     "webpack": "^4.19.0",

--- a/packages/redux-query-react/package.json
+++ b/packages/redux-query-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "redux-query-react",
-  "version": "3.2.1",
+  "version": "3.3.0-alpha.0",
   "description": "The React interface for integrating with redux-query",
   "homepage": "https://github.com/amplitude/redux-query",
   "main": "dist/commonjs/index.js",

--- a/packages/redux-query-react/package.json
+++ b/packages/redux-query-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "redux-query-react",
-  "version": "3.3.0-alpha.1",
+  "version": "3.3.0-alpha.2",
   "description": "The React interface for integrating with redux-query",
   "homepage": "https://github.com/amplitude/redux-query",
   "main": "dist/commonjs/index.js",
@@ -68,7 +68,7 @@
     "react-redux": "7.1.0",
     "react-test-renderer": "^16.8.6",
     "redux": "^4.0.1",
-    "redux-query": "^3.3.0-alpha.1",
+    "redux-query": "^3.3.0-alpha.2",
     "rimraf": "^2.4.3",
     "terser-webpack-plugin": "^1.3.0",
     "webpack": "^4.19.0",

--- a/packages/redux-query-react/package.json
+++ b/packages/redux-query-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "redux-query-react",
-  "version": "3.3.0-alpha.2",
+  "version": "3.3.0-alpha.3",
   "description": "The React interface for integrating with redux-query",
   "homepage": "https://github.com/amplitude/redux-query",
   "main": "dist/commonjs/index.js",
@@ -68,7 +68,7 @@
     "react-redux": "7.1.0",
     "react-test-renderer": "^16.8.6",
     "redux": "^4.0.1",
-    "redux-query": "^3.3.0-alpha.2",
+    "redux-query": "^3.3.0-alpha.3",
     "rimraf": "^2.4.3",
     "terser-webpack-plugin": "^1.3.0",
     "webpack": "^4.19.0",

--- a/packages/redux-query-react/src/components/connect-request.js
+++ b/packages/redux-query-react/src/components/connect-request.js
@@ -88,13 +88,27 @@ const useMultiRequest = <Config>(mapPropsToConfigs: MapPropsToConfigs<Config>, p
     }
   });
 
+  const finishedCallback = useConstCallback(() => {
+    (queryKey: QueryKey) => {
+      pendingRequests.current.delete(queryKey);
+    };
+  });
+
+  const transformQueryConfig = useConstCallback(
+    (queryConfig: ?QueryConfig): ?QueryConfig => {
+      return {
+        ...queryConfig,
+        unstable_preDispatchCallback: finishedCallback,
+        retry: true,
+      };
+    },
+  );
+
   // Query configs are memoized based on query key. As long as the query keys in the list don't
   // change, the query config list won't change.
   const queryConfigs = useMemoizedQueryConfigs(
     normalizeToArray(mapPropsToConfigs(props)),
-    (queryKey: QueryKey) => {
-      pendingRequests.current.delete(queryKey);
-    },
+    transformQueryConfig,
   );
 
   const forceRequest = React.useCallback(() => {

--- a/packages/redux-query-react/src/components/connect-request.js
+++ b/packages/redux-query-react/src/components/connect-request.js
@@ -2,10 +2,13 @@
 
 import hoistStatics from 'hoist-non-react-statics';
 import * as React from 'react';
+import { useDispatch } from 'react-redux';
+import { requestAsync, cancelQuery, getQueryKey } from 'redux-query';
 
-import type { QueryConfig } from 'redux-query/types.js.flow';
+import type { QueryConfig, QueryKey } from 'redux-query/types.js.flow';
 
-import useRequests from '../hooks/use-requests';
+import useConstCallback from '../hooks/use-const-callback';
+import useMemoizedQueryConfigs from '../hooks/use-memoized-query-configs';
 
 type MapPropsToConfigs<T> = (props: T) => QueryConfig | Array<QueryConfig>;
 
@@ -14,8 +17,118 @@ type Options = {|
   pure?: boolean,
 |};
 
-const normalizeToArray = (maybe: QueryConfig | Array<QueryConfig>): ?Array<QueryConfig> => {
+const normalizeToArray = (maybe: QueryConfig | Array<QueryConfig>): Array<QueryConfig> => {
   return (Array.isArray(maybe) ? maybe : [maybe]).filter(Boolean);
+};
+
+const difference = <T>(a: $ReadOnlyArray<T>, b: $ReadOnlyArray<T>): Array<T> => {
+  const bSet = new Set(b);
+
+  return a.filter(x => !bSet.has(x));
+};
+
+const diffQueryConfigs = (
+  prevQueryConfigs: Array<QueryConfig>,
+  queryConfigs: Array<QueryConfig>,
+) => {
+  const prevQueryKeys = prevQueryConfigs.map(config => getQueryKey(config));
+  const queryKeys = queryConfigs.map(config => getQueryKey(config));
+  const queryConfigByQueryKey = queryKeys.reduce((accum, queryKey: ?QueryKey, i) => {
+    const queryConfig = queryConfigs[i];
+
+    if (queryConfig) {
+      accum.set(queryKey, queryConfig);
+    }
+
+    return accum;
+  }, new Map());
+
+  // Keys that existed before that no longer exist, should be subject to cancellation
+  const cancelKeys = difference(prevQueryKeys, queryKeys).filter(Boolean);
+
+  // Keys that are new, should be subject to a new request
+  const requestKeys = difference(queryKeys, prevQueryKeys).filter(Boolean);
+  const requestQueryConfigs = requestKeys
+    .map(queryKey => queryConfigByQueryKey.get(queryKey))
+    .filter(Boolean);
+
+  return { cancelKeys, requestQueryConfigs };
+};
+
+const useMultiRequest = <Config>(mapPropsToConfigs: MapPropsToConfigs<Config>, props: Config) => {
+  const reduxDispatch = useDispatch();
+
+  const previousQueryConfigs = React.useRef<Array<QueryConfig>>([]);
+
+  // This hook manually tracks the pending state, which is synchronized as precisely as possible
+  // with the Redux state. This may seem a little hacky, but we're trying to avoid any asynchronous
+  // synchronization. Hence why the pending state here is using a ref and it is updated via a
+  // synchronous callback, which is called from the redux-query query middleware.
+  const pendingRequests = React.useRef<Set<QueryKey>>(new Set());
+
+  // These "const callbacks" are memoized across re-renders. Unlike useCallback, useConstCallback
+  // guarantees memoization, which is relied upon elsewhere in this hook to explicitly control when
+  // certain side effects occur.
+  const dispatchRequestToRedux = useConstCallback((queryConfig: QueryConfig) => {
+    const promise = reduxDispatch(requestAsync(queryConfig));
+
+    if (promise) {
+      const queryKey = getQueryKey(queryConfig);
+
+      if (queryKey) {
+        pendingRequests.current.add(queryKey);
+      }
+    }
+  });
+
+  const dispatchCancelToRedux = useConstCallback((queryKey: QueryKey) => {
+    if (pendingRequests.current.has(queryKey)) {
+      reduxDispatch(cancelQuery(queryKey));
+      pendingRequests.current.delete(queryKey);
+    }
+  });
+
+  // Query configs are memoized based on query key. As long as the query keys in the list don't
+  // change, the query config list won't change.
+  const queryConfigs = useMemoizedQueryConfigs(
+    normalizeToArray(mapPropsToConfigs(props)),
+    (queryKey: QueryKey) => {
+      pendingRequests.current.delete(queryKey);
+    },
+  );
+
+  const forceRequest = React.useCallback(() => {
+    queryConfigs.forEach(requestReduxAction => {
+      dispatchRequestToRedux({
+        ...requestReduxAction,
+        force: true,
+      });
+    });
+  }, [dispatchRequestToRedux, queryConfigs]);
+
+  React.useEffect(() => {
+    // Whenever the list of query configs change, we need to manually diff the query configs
+    // against the previous list of query configs. Whatever was there and is no longer, will be
+    // cancelled. Whatever is new, will turn into a request.
+    const { cancelKeys, requestQueryConfigs } = diffQueryConfigs(
+      previousQueryConfigs.current,
+      queryConfigs,
+    );
+
+    requestQueryConfigs.forEach(dispatchRequestToRedux);
+    cancelKeys.forEach(queryKey => dispatchCancelToRedux(queryKey));
+
+    previousQueryConfigs.current = queryConfigs;
+  }, [dispatchCancelToRedux, dispatchRequestToRedux, queryConfigs]);
+
+  // When the component unmounts, cancel all pending requests
+  React.useEffect(() => {
+    return () => {
+      [...pendingRequests.current].forEach(dispatchCancelToRedux);
+    };
+  }, [dispatchCancelToRedux]);
+
+  return forceRequest;
 };
 
 type Wrapper<Config> = (
@@ -36,9 +149,7 @@ const connectRequest = <Config: {}>(
   const { pure = true, forwardRef = false } = options || {};
 
   const ConnectRequestFunction = (props: Config) => {
-    const queryConfigs = normalizeToArray(mapPropsToConfigs(props));
-
-    const [, forceRequest] = useRequests(queryConfigs);
+    const forceRequest = useMultiRequest<Config>(mapPropsToConfigs, props);
 
     return <WrappedComponent {...props} forceRequest={forceRequest} />;
   };

--- a/packages/redux-query-react/src/components/connect-request.js
+++ b/packages/redux-query-react/src/components/connect-request.js
@@ -2,13 +2,10 @@
 
 import hoistStatics from 'hoist-non-react-statics';
 import * as React from 'react';
-import { useDispatch } from 'react-redux';
-import { requestAsync, cancelQuery, getQueryKey } from 'redux-query';
 
-import type { QueryConfig, QueryKey } from 'redux-query/types.js.flow';
+import type { QueryConfig } from 'redux-query/types.js.flow';
 
-import useConstCallback from '../hooks/use-const-callback';
-import useMemoizedQueryConfigs from '../hooks/use-memoized-query-configs';
+import useRequests from '../hooks/use-requests';
 
 type MapPropsToConfigs<T> = (props: T) => QueryConfig | Array<QueryConfig>;
 
@@ -17,118 +14,8 @@ type Options = {|
   pure?: boolean,
 |};
 
-const normalizeToArray = (maybe: QueryConfig | Array<QueryConfig>): Array<QueryConfig> => {
+const normalizeToArray = (maybe: QueryConfig | Array<QueryConfig>): ?Array<QueryConfig> => {
   return (Array.isArray(maybe) ? maybe : [maybe]).filter(Boolean);
-};
-
-const difference = <T>(a: $ReadOnlyArray<T>, b: $ReadOnlyArray<T>): Array<T> => {
-  const bSet = new Set(b);
-
-  return a.filter(x => !bSet.has(x));
-};
-
-const diffQueryConfigs = (
-  prevQueryConfigs: Array<QueryConfig>,
-  queryConfigs: Array<QueryConfig>,
-) => {
-  const prevQueryKeys = prevQueryConfigs.map(config => getQueryKey(config));
-  const queryKeys = queryConfigs.map(config => getQueryKey(config));
-  const queryConfigByQueryKey = queryKeys.reduce((accum, queryKey: ?QueryKey, i) => {
-    const queryConfig = queryConfigs[i];
-
-    if (queryConfig) {
-      accum.set(queryKey, queryConfig);
-    }
-
-    return accum;
-  }, new Map());
-
-  // Keys that existed before that no longer exist, should be subject to cancellation
-  const cancelKeys = difference(prevQueryKeys, queryKeys).filter(Boolean);
-
-  // Keys that are new, should be subject to a new request
-  const requestKeys = difference(queryKeys, prevQueryKeys).filter(Boolean);
-  const requestQueryConfigs = requestKeys
-    .map(queryKey => queryConfigByQueryKey.get(queryKey))
-    .filter(Boolean);
-
-  return { cancelKeys, requestQueryConfigs };
-};
-
-const useMultiRequest = <Config>(mapPropsToConfigs: MapPropsToConfigs<Config>, props: Config) => {
-  const reduxDispatch = useDispatch();
-
-  const previousQueryConfigs = React.useRef<Array<QueryConfig>>([]);
-
-  // This hook manually tracks the pending state, which is synchronized as precisely as possible
-  // with the Redux state. This may seem a little hacky, but we're trying to avoid any asynchronous
-  // synchronization. Hence why the pending state here is using a ref and it is updated via a
-  // synchronous callback, which is called from the redux-query query middleware.
-  const pendingRequests = React.useRef<Set<QueryKey>>(new Set());
-
-  // These "const callbacks" are memoized across re-renders. Unlike useCallback, useConstCallback
-  // guarantees memoization, which is relied upon elsewhere in this hook to explicitly control when
-  // certain side effects occur.
-  const dispatchRequestToRedux = useConstCallback((queryConfig: QueryConfig) => {
-    const promise = reduxDispatch(requestAsync(queryConfig));
-
-    if (promise) {
-      const queryKey = getQueryKey(queryConfig);
-
-      if (queryKey) {
-        pendingRequests.current.add(queryKey);
-      }
-    }
-  });
-
-  const dispatchCancelToRedux = useConstCallback((queryKey: QueryKey) => {
-    if (pendingRequests.current.has(queryKey)) {
-      reduxDispatch(cancelQuery(queryKey));
-      pendingRequests.current.delete(queryKey);
-    }
-  });
-
-  // Query configs are memoized based on query key. As long as the query keys in the list don't
-  // change, the query config list won't change.
-  const queryConfigs = useMemoizedQueryConfigs(
-    normalizeToArray(mapPropsToConfigs(props)),
-    (queryKey: QueryKey) => {
-      pendingRequests.current.delete(queryKey);
-    },
-  );
-
-  const forceRequest = React.useCallback(() => {
-    queryConfigs.forEach(requestReduxAction => {
-      dispatchRequestToRedux({
-        ...requestReduxAction,
-        force: true,
-      });
-    });
-  }, [dispatchRequestToRedux, queryConfigs]);
-
-  React.useEffect(() => {
-    // Whenever the list of query configs change, we need to manually diff the query configs
-    // against the previous list of query configs. Whatever was there and is no longer, will be
-    // cancelled. Whatever is new, will turn into a request.
-    const { cancelKeys, requestQueryConfigs } = diffQueryConfigs(
-      previousQueryConfigs.current,
-      queryConfigs,
-    );
-
-    requestQueryConfigs.forEach(dispatchRequestToRedux);
-    cancelKeys.forEach(queryKey => dispatchCancelToRedux(queryKey));
-
-    previousQueryConfigs.current = queryConfigs;
-  }, [dispatchCancelToRedux, dispatchRequestToRedux, queryConfigs]);
-
-  // When the component unmounts, cancel all pending requests
-  React.useEffect(() => {
-    return () => {
-      [...pendingRequests.current].forEach(dispatchCancelToRedux);
-    };
-  }, [dispatchCancelToRedux]);
-
-  return forceRequest;
 };
 
 type Wrapper<Config> = (
@@ -149,7 +36,9 @@ const connectRequest = <Config: {}>(
   const { pure = true, forwardRef = false } = options || {};
 
   const ConnectRequestFunction = (props: Config) => {
-    const forceRequest = useMultiRequest<Config>(mapPropsToConfigs, props);
+    const queryConfigs = normalizeToArray(mapPropsToConfigs(props));
+
+    const [, forceRequest] = useRequests(queryConfigs);
 
     return <WrappedComponent {...props} forceRequest={forceRequest} />;
   };

--- a/packages/redux-query-react/src/hooks/use-memoized-query-configs.js
+++ b/packages/redux-query-react/src/hooks/use-memoized-query-configs.js
@@ -1,0 +1,62 @@
+// @flow
+
+import * as React from 'react';
+import { getQueryKey } from 'redux-query';
+
+import type { QueryConfig, QueryKey } from 'redux-query/types.js.flow';
+
+/**
+ * This hook memoizes the list of query configs that are returned form the `mapPropsToConfigs`
+ * function. It also transforms the query configs to set `retry` to `true` and pass a
+ * synchronous callback to track pending state.
+ *
+ * `mapPropsToConfigs` may return null, undefined, a single query config,
+ * or a list of query configs. null and undefined values are ignored, and single query configs are
+ * normalized to be lists.
+ *
+ * Memoization is handled by comparing query keys. If the list changes in size, or any query config
+ * in the list's query key changes, an entirely new list of query configs is returned.
+ */
+
+const useMemoizedQueryConfigs = (
+  providedQueryConfigs: Array<QueryConfig>,
+  callback: (queryKey: QueryKey) => void,
+) => {
+  const queryConfigs = providedQueryConfigs
+    .map(
+      (queryConfig: ?QueryConfig): ?QueryConfig => {
+        const queryKey = getQueryKey(queryConfig);
+
+        if (queryKey) {
+          return {
+            ...queryConfig,
+            retry: true,
+            unstable_preDispatchCallback: () => {
+              callback(queryKey);
+            },
+          };
+        }
+      },
+    )
+    .filter(Boolean);
+  const [memoizedQueryConfigs, setMemoizedQueryConfigs] = React.useState(queryConfigs);
+  const previousQueryKeys = React.useRef<Array<QueryKey>>(
+    queryConfigs.map(getQueryKey).filter(Boolean),
+  );
+
+  React.useEffect(() => {
+    const queryKeys = queryConfigs.map(getQueryKey).filter(Boolean);
+
+    if (
+      queryKeys.length !== previousQueryKeys.current.length ||
+      queryKeys.some((queryKey, i) => previousQueryKeys.current[i] !== queryKey)
+    ) {
+      previousQueryKeys.current = queryKeys;
+      setMemoizedQueryConfigs(queryConfigs);
+    }
+  }, [queryConfigs]);
+
+  return memoizedQueryConfigs;
+};
+
+export default useMemoizedQueryConfigs;

--- a/packages/redux-query-react/src/hooks/use-memoized-query-configs.js
+++ b/packages/redux-query-react/src/hooks/use-memoized-query-configs.js
@@ -5,6 +5,8 @@ import { getQueryKey } from 'redux-query';
 
 import type { QueryConfig, QueryKey } from 'redux-query/types.js.flow';
 
+const identity = x => x;
+
 /**
  * This hook memoizes the list of query configs that are returned form the `mapPropsToConfigs`
  * function. It also transforms the query configs to set `retry` to `true` and pass a
@@ -20,7 +22,7 @@ import type { QueryConfig, QueryKey } from 'redux-query/types.js.flow';
 
 const useMemoizedQueryConfigs = (
   providedQueryConfigs: ?Array<QueryConfig>,
-  callback: (queryKey: QueryKey) => void,
+  transform: (?QueryConfig) => ?QueryConfig = identity,
 ) => {
   const queryConfigs = providedQueryConfigs
     ? providedQueryConfigs
@@ -29,13 +31,7 @@ const useMemoizedQueryConfigs = (
             const queryKey = getQueryKey(queryConfig);
 
             if (queryKey) {
-              return {
-                ...queryConfig,
-                retry: true,
-                unstable_preDispatchCallback: () => {
-                  callback(queryKey);
-                },
-              };
+              return transform(queryConfig);
             }
           },
         )

--- a/packages/redux-query-react/src/hooks/use-memoized-query-configs.js
+++ b/packages/redux-query-react/src/hooks/use-memoized-query-configs.js
@@ -19,26 +19,28 @@ import type { QueryConfig, QueryKey } from 'redux-query/types.js.flow';
  */
 
 const useMemoizedQueryConfigs = (
-  providedQueryConfigs: Array<QueryConfig>,
+  providedQueryConfigs: ?Array<QueryConfig>,
   callback: (queryKey: QueryKey) => void,
 ) => {
   const queryConfigs = providedQueryConfigs
-    .map(
-      (queryConfig: ?QueryConfig): ?QueryConfig => {
-        const queryKey = getQueryKey(queryConfig);
+    ? providedQueryConfigs
+        .map(
+          (queryConfig: ?QueryConfig): ?QueryConfig => {
+            const queryKey = getQueryKey(queryConfig);
 
-        if (queryKey) {
-          return {
-            ...queryConfig,
-            retry: true,
-            unstable_preDispatchCallback: () => {
-              callback(queryKey);
-            },
-          };
-        }
-      },
-    )
-    .filter(Boolean);
+            if (queryKey) {
+              return {
+                ...queryConfig,
+                retry: true,
+                unstable_preDispatchCallback: () => {
+                  callback(queryKey);
+                },
+              };
+            }
+          },
+        )
+        .filter(Boolean)
+    : [];
   const [memoizedQueryConfigs, setMemoizedQueryConfigs] = React.useState(queryConfigs);
   const previousQueryKeys = React.useRef<Array<QueryKey>>(
     queryConfigs.map(getQueryKey).filter(Boolean),

--- a/packages/redux-query-react/src/hooks/use-queries-state.js
+++ b/packages/redux-query-react/src/hooks/use-queries-state.js
@@ -1,0 +1,43 @@
+// @flow
+
+import * as React from 'react';
+import { useSelector } from 'react-redux';
+import { querySelectors } from 'redux-query';
+import type { QueryConfig } from 'redux-query/types.js.flow';
+
+import ReduxQueryContext from '../context';
+import type { QueriesState } from '../types';
+
+const useQueriesState = (queryConfig: Array<QueryConfig>): QueriesState => {
+  const contextValue = React.useContext(ReduxQueryContext);
+
+  if (!contextValue) {
+    throw new Error(
+      `Could not find redux-query-react's context. Be sure to render a redux-query <Provider> near the root of your React tree.`,
+    );
+  }
+
+  const { queriesSelector } = contextValue;
+
+  const queriesState = useSelector(queriesSelector);
+
+  const isPending = queryConfig.some(queryConfig =>
+    querySelectors.isPending(queriesState, queryConfig),
+  );
+
+  const isFinished = queryConfig.every(queryConfig =>
+    querySelectors.isFinished(queriesState, queryConfig),
+  );
+
+  const queryState = React.useMemo(
+    () => ({
+      isPending,
+      isFinished,
+    }),
+    [isFinished, isPending],
+  );
+
+  return queryState;
+};
+
+export default useQueriesState;

--- a/packages/redux-query-react/src/hooks/use-request.js
+++ b/packages/redux-query-react/src/hooks/use-request.js
@@ -13,7 +13,7 @@ import useQueryState from './use-query-state';
 import type { QueryState } from '../types';
 
 const useRequest = (
-  providedQueryConfig: ?QueryConfig,
+  providedQueryConfig: QueryConfig,
 ): [QueryState, () => ?Promise<ActionPromiseValue>] => {
   const reduxDispatch = useDispatch();
 

--- a/packages/redux-query-react/src/hooks/use-request.js
+++ b/packages/redux-query-react/src/hooks/use-request.js
@@ -13,7 +13,7 @@ import useQueryState from './use-query-state';
 import type { QueryState } from '../types';
 
 const useRequest = (
-  providedQueryConfig: QueryConfig,
+  providedQueryConfig: ?QueryConfig,
 ): [QueryState, () => ?Promise<ActionPromiseValue>] => {
   const reduxDispatch = useDispatch();
 

--- a/packages/redux-query-react/src/hooks/use-requests.js
+++ b/packages/redux-query-react/src/hooks/use-requests.js
@@ -47,7 +47,7 @@ const diffQueryConfigs = (
 };
 
 const useRequests = (
-  providedQueryConfigs: Array<QueryConfig>,
+  providedQueryConfigs: ?Array<QueryConfig>,
 ): [QueriesState, () => ?Promise<ActionPromiseValue>] => {
   const reduxDispatch = useDispatch();
 

--- a/packages/redux-query-react/src/hooks/use-requests.js
+++ b/packages/redux-query-react/src/hooks/use-requests.js
@@ -81,11 +81,25 @@ const useRequests = (
     }
   });
 
+  const finishedCallback = useConstCallback(() => {
+    (queryKey: QueryKey) => {
+      pendingRequests.current.delete(queryKey);
+    };
+  });
+
+  const transformQueryConfig = useConstCallback(
+    (queryConfig: ?QueryConfig): ?QueryConfig => {
+      return {
+        ...queryConfig,
+        unstable_preDispatchCallback: finishedCallback,
+        retry: true,
+      };
+    },
+  );
+
   // Query configs are memoized based on query key. As long as the query keys in the list don't
   // change, the query config list won't change.
-  const queryConfigs = useMemoizedQueryConfigs(providedQueryConfigs, (queryKey: QueryKey) => {
-    pendingRequests.current.delete(queryKey);
-  });
+  const queryConfigs = useMemoizedQueryConfigs(providedQueryConfigs, transformQueryConfig);
 
   // This is an object containing two variables, isPending and isFinished, these apply to all queries.
   // If any queries are pending, isPending is true, and

--- a/packages/redux-query-react/src/index.js
+++ b/packages/redux-query-react/src/index.js
@@ -4,8 +4,10 @@ import connectRequest from './components/connect-request';
 import Provider from './components/Provider';
 import useMutation from './hooks/use-mutation';
 import useRequest from './hooks/use-request';
+import useRequests from './hooks/use-requests';
 
 export { connectRequest };
 export { Provider };
 export { useMutation };
 export { useRequest };
+export { useRequests };

--- a/packages/redux-query-react/src/types.js
+++ b/packages/redux-query-react/src/types.js
@@ -8,3 +8,8 @@ export type QueryState = {|
   queryCount: number,
   status: ?number,
 |};
+
+export type QueriesState = {|
+  isFinished: boolean,
+  isPending: boolean,
+|};

--- a/packages/redux-query-react/test/hooks/use-requests.test.js
+++ b/packages/redux-query-react/test/hooks/use-requests.test.js
@@ -1,0 +1,273 @@
+import * as React from 'react';
+import { render, waitForElement, getByTestId, fireEvent } from '@testing-library/react';
+import { Provider, useSelector } from 'react-redux';
+import { applyMiddleware, createStore, combineReducers } from 'redux';
+import { entitiesReducer, queriesReducer, queryMiddleware } from 'redux-query';
+
+import useRequests from '../../src/hooks/use-requests';
+import ReduxQueryProvider from '../../src/components/Provider';
+
+export const getQueries = state => state.queries;
+export const getEntities = state => state.entities;
+
+const reducer = combineReducers({
+  entities: entitiesReducer,
+  queries: queriesReducer,
+});
+
+const artificialNetworkDelay = 100;
+const apiMessage = 'hello, world!';
+
+const mockNetworkInterface = url => {
+  let timeoutId = null;
+
+  return {
+    abort() {
+      clearTimeout(timeoutId);
+    },
+    execute(callback) {
+      if (url === '/api') {
+        timeoutId = setTimeout(() => {
+          const status = 200;
+          const body = {
+            message: apiMessage,
+          };
+          const text = JSON.stringify(body);
+          const headers = {};
+
+          callback(null, status, body, text, headers);
+        }, artificialNetworkDelay);
+      }
+      if (url === '/test') {
+        timeoutId = setTimeout(() => {
+          const status = 200;
+          const body = {
+            message: apiMessage,
+          };
+          const text = JSON.stringify(body);
+          const headers = {};
+
+          callback(null, status, body, text, headers);
+        }, artificialNetworkDelay);
+      } else {
+        timeoutId = setTimeout(() => {
+          callback(null, 404, {}, '{}', {});
+        }, artificialNetworkDelay);
+      }
+    },
+  };
+};
+
+let store;
+
+const App = props => {
+  return (
+    <Provider store={store}>
+      <ReduxQueryProvider queriesSelector={getQueries}>{props.children}</ReduxQueryProvider>
+    </Provider>
+  );
+};
+
+describe('useRequests', () => {
+  beforeEach(() => {
+    store = createStore(
+      reducer,
+      applyMiddleware(queryMiddleware(mockNetworkInterface, getQueries, getEntities)),
+    );
+  });
+
+  it('loads data initially and supports refresh', async () => {
+    const Content = () => {
+      const [{ isPending }, refresh] = useRequests([
+        {
+          url: '/api',
+          update: {
+            message: (prevValue, newValue) => newValue,
+          },
+        },
+        {
+          url: '/test',
+          update: {
+            message: (prevValue, newValue) => newValue,
+          },
+        },
+      ]);
+      const message = useSelector(state => state.entities.message);
+
+      if (isPending) {
+        return <div data-testid="loading-content">loading</div>;
+      }
+
+      return (
+        <div>
+          <div data-testid="loaded-content">{message}</div>
+          <button data-testid="refresh-button" onClick={refresh}>
+            refresh
+          </button>
+        </div>
+      );
+    };
+
+    const { container } = render(
+      <App>
+        <Content />
+      </App>,
+    );
+
+    // Initial loading
+
+    let loadingContentNode = getByTestId(container, 'loading-content');
+    expect(loadingContentNode.textContent).toBe('loading');
+
+    // Loaded
+
+    let loadedContentNode = await waitForElement(() => getByTestId(container, 'loaded-content'));
+    expect(loadedContentNode.textContent).toBe(apiMessage);
+
+    // Click refresh button
+
+    let buttonNode = getByTestId(container, 'refresh-button');
+    fireEvent.click(buttonNode);
+
+    // We're in a loading state again
+
+    loadingContentNode = await waitForElement(() => getByTestId(container, 'loading-content'));
+    expect(loadingContentNode.textContent).toBe('loading');
+
+    // Loaded again
+
+    loadedContentNode = await waitForElement(() => getByTestId(container, 'loaded-content'));
+    expect(loadedContentNode.textContent).toBe(apiMessage);
+  });
+
+  it('cancels pending requests as part of cleanup', async () => {
+    const Content = () => {
+      const [{ isPending }, refresh] = useRequests([
+        {
+          url: '/api',
+          update: {
+            message: (prevValue, newValue) => newValue,
+          },
+        },
+        {
+          url: '/test',
+          update: {
+            message: (prevValue, newValue) => newValue,
+          },
+        },
+      ]);
+      const message = useSelector(state => state.entities.message);
+
+      if (isPending) {
+        return <div data-testid="loading-content">loading</div>;
+      }
+
+      return (
+        <div>
+          <div data-testid="loaded-content">{message}</div>
+          <button data-testid="refresh-button" onClick={refresh}>
+            refresh
+          </button>
+        </div>
+      );
+    };
+
+    const Router = () => {
+      const [path, setPath] = React.useState('/');
+
+      return (
+        <div>
+          {path === '/' ? <Content /> : <div data-testid="404">404</div>}
+          <a
+            data-testid="broken-link"
+            href="/broken-link"
+            onClick={e => {
+              e.preventDefault();
+              setPath('broken-link');
+            }}
+          >
+            broken link
+          </a>
+          <a
+            data-testid="home-link"
+            href="/"
+            onClick={e => {
+              e.preventDefault();
+              setPath('/');
+            }}
+          >
+            home link
+          </a>
+        </div>
+      );
+    };
+
+    const { container } = render(
+      <App>
+        <Router />
+      </App>,
+    );
+
+    // Initial loading of the component that has the useRequests hook
+
+    let loadingContentNode = getByTestId(container, 'loading-content');
+    expect(loadingContentNode.textContent).toBe('loading');
+
+    // Click broken link before component has finished loading. By clicking the link, we are
+    // unmounting the component that has the useRequests hook, triggering the network request to be
+    // canceled.
+
+    let brokenLinkNode = await waitForElement(() => getByTestId(container, 'broken-link'));
+    fireEvent.click(brokenLinkNode);
+
+    // 404 page loaded - check that query was actually canceled in Redux
+
+    let notFoundNode = await waitForElement(() => getByTestId(container, '404'));
+    expect(notFoundNode.textContent).toBe('404');
+    expect(store.getState().queries['{"url":"/api"}'].isPending).toBe(false);
+    expect(store.getState().entities.message).toBeUndefined();
+
+    // Go back home
+
+    let homeLinkNode = await waitForElement(() => getByTestId(container, 'home-link'));
+    fireEvent.click(homeLinkNode);
+
+    // Check that query begins again
+
+    loadingContentNode = await waitForElement(() => getByTestId(container, 'loading-content'));
+    expect(loadingContentNode.textContent).toBe('loading');
+
+    // Loaded now
+
+    const loadedContentNode = await waitForElement(() => getByTestId(container, 'loaded-content'));
+    expect(loadedContentNode.textContent).toBe(apiMessage);
+  });
+
+  it('does nothing if query config is null', async () => {
+    const Content = () => {
+      const [{ isPending }] = useRequests(null);
+      const message = useSelector(state => state.entities.message);
+
+      if (isPending) {
+        return <div data-testid="loading-content">loading</div>;
+      }
+
+      return (
+        <div>
+          <div data-testid="loaded-content">{message}</div>
+        </div>
+      );
+    };
+
+    const { container } = render(
+      <App>
+        <Content />
+      </App>,
+    );
+
+    // It never loads
+
+    let loadedContentNode = getByTestId(container, 'loaded-content');
+    expect(loadedContentNode.textContent).toBe('');
+  });
+});

--- a/packages/redux-query-react/yarn.lock
+++ b/packages/redux-query-react/yarn.lock
@@ -1434,11 +1434,6 @@ babel-preset-jest@^24.6.0:
     "@babel/plugin-syntax-object-rest-spread" "^7.0.0"
     babel-plugin-jest-hoist "^24.6.0"
 
-backo@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/backo/-/backo-1.1.0.tgz#a36c4468923f2d265c9e8a709ea56ecdaff807e6"
-  integrity sha1-o2xEaJI/LSZcnopwnqVuza/4B+Y=
-
 balanced-match@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.0.tgz#89b4d199ab2bee49de164ea02b89ce462d71b767"
@@ -3067,11 +3062,6 @@ iconv-lite@0.4.24, iconv-lite@^0.4.24, iconv-lite@^0.4.4:
   dependencies:
     safer-buffer ">= 2.1.2 < 3"
 
-idx@^2.5.6:
-  version "2.5.6"
-  resolved "https://registry.yarnpkg.com/idx/-/idx-2.5.6.tgz#1f824595070100ae9ad585c86db08dc74f83a59d"
-  integrity sha512-WFXLF7JgPytbMgelpRY46nHz5tyDcedJ76pLV+RJWdb8h33bxFq4bdZau38DhNSzk5eVniBf1K3jwfK+Lb5nYA==
-
 ieee754@^1.1.4:
   version "1.1.13"
   resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.1.13.tgz#ec168558e95aa181fd87d37f55c32bbcb6708b84"
@@ -3167,7 +3157,7 @@ interpret@^1.1.0:
   resolved "https://registry.yarnpkg.com/interpret/-/interpret-1.2.0.tgz#d5061a6224be58e8083985f5014d844359576296"
   integrity sha512-mT34yGKMNceBQUoVn7iCDKDntA7SC6gycMAWzGx1z/CMCTV7b2AAtXlo3nRyHZ1FelRkQbQjprHSYGwzLtkVbw==
 
-invariant@^2.2.0, invariant@^2.2.2, invariant@^2.2.4:
+invariant@^2.2.2, invariant@^2.2.4:
   version "2.2.4"
   resolved "https://registry.yarnpkg.com/invariant/-/invariant-2.2.4.tgz#610f3c92c9359ce1db616e538008d23ff35158e6"
   integrity sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==
@@ -3874,13 +3864,6 @@ json-stable-stringify-without-jsonify@^1.0.1:
   resolved "https://registry.yarnpkg.com/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz#9db7b59496ad3f3cfef30a75142d2d930ad72651"
   integrity sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=
 
-json-stable-stringify@^1.0.0:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz#9a759d39c5f2ff503fd5300646ed445f88c4f9af"
-  integrity sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=
-  dependencies:
-    jsonify "~0.0.0"
-
 json-stringify-safe@~5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz#1296a2d58fd45f19a0f6ce01d65701e2c735b6eb"
@@ -3899,11 +3882,6 @@ json5@^2.1.0:
   integrity sha512-8Mh9h6xViijj36g7Dxi+Y4S6hNGV96vcJZr/SrlHh1LR/pEn/8j/+qIBbs44YKl69Lrfctp4QD+AdWLTMqEZAQ==
   dependencies:
     minimist "^1.2.0"
-
-jsonify@~0.0.0:
-  version "0.0.0"
-  resolved "https://registry.yarnpkg.com/jsonify/-/jsonify-0.0.0.tgz#2c74b6ee41d93ca51b7b5aaee8f503631d252a73"
-  integrity sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=
 
 jsprim@^1.2.2:
   version "1.4.1"
@@ -5242,16 +5220,6 @@ realpath-native@^1.1.0:
   integrity sha512-wlgPA6cCIIg9gKz0fgAPjnzh4yR/LnXovwuo9hvyGvx3h8nX4+/iLZplfUWasXpqD8BdnGnP5njOFjkUwPzvjA==
   dependencies:
     util.promisify "^1.0.0"
-
-redux-query@^3.2.0:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/redux-query/-/redux-query-3.2.0.tgz#542451535b1de93194a5fa93a33e33bf1aaa4a31"
-  integrity sha512-bkpP5ZchxWqst4KHwiA8la9j8UL5q4W4wJbapyVWkeEqagPFTMmguDZz4kQTP3Bgq7uX+pX/RWGU7Nb0cxO26A==
-  dependencies:
-    backo "^1.1.0"
-    idx "^2.5.6"
-    invariant "^2.2.0"
-    json-stable-stringify "^1.0.0"
 
 redux@^4.0.1:
   version "4.0.1"

--- a/packages/redux-query/README.md
+++ b/packages/redux-query/README.md
@@ -30,6 +30,7 @@ A library for managing network state in Redux.
 ## React API
 
 - [useRequest](https://amplitude.github.io/redux-query/docs/use-request)
+- [useRequests](https://amplitude.github.io/redux-query/docs/use-requests)
 - [useMutation](https://amplitude.github.io/redux-query/docs/use-mutation)
 - [connectRequest](https://amplitude.github.io/redux-query/docs/connect-request)
 

--- a/packages/redux-query/package.json
+++ b/packages/redux-query/package.json
@@ -1,6 +1,6 @@
 {
   "name": "redux-query",
-  "version": "3.3.0-rc.0",
+  "version": "3.3.0",
   "description": "A library for querying and managing network state in Redux applications",
   "homepage": "https://github.com/amplitude/redux-query",
   "main": "dist/commonjs/index.js",

--- a/packages/redux-query/package.json
+++ b/packages/redux-query/package.json
@@ -1,6 +1,6 @@
 {
   "name": "redux-query",
-  "version": "3.2.1",
+  "version": "3.3.0-alpha.1",
   "description": "A library for querying and managing network state in Redux applications",
   "homepage": "https://github.com/amplitude/redux-query",
   "main": "dist/commonjs/index.js",

--- a/packages/redux-query/package.json
+++ b/packages/redux-query/package.json
@@ -1,6 +1,6 @@
 {
   "name": "redux-query",
-  "version": "3.3.0-alpha.1",
+  "version": "3.3.0-alpha.2",
   "description": "A library for querying and managing network state in Redux applications",
   "homepage": "https://github.com/amplitude/redux-query",
   "main": "dist/commonjs/index.js",

--- a/packages/redux-query/package.json
+++ b/packages/redux-query/package.json
@@ -1,6 +1,6 @@
 {
   "name": "redux-query",
-  "version": "3.3.0-alpha.2",
+  "version": "3.3.0-alpha.3",
   "description": "A library for querying and managing network state in Redux applications",
   "homepage": "https://github.com/amplitude/redux-query",
   "main": "dist/commonjs/index.js",

--- a/packages/redux-query/package.json
+++ b/packages/redux-query/package.json
@@ -1,6 +1,6 @@
 {
   "name": "redux-query",
-  "version": "3.3.0-alpha.3",
+  "version": "3.3.0-alpha.4",
   "description": "A library for querying and managing network state in Redux applications",
   "homepage": "https://github.com/amplitude/redux-query",
   "main": "dist/commonjs/index.js",

--- a/packages/redux-query/package.json
+++ b/packages/redux-query/package.json
@@ -1,6 +1,6 @@
 {
   "name": "redux-query",
-  "version": "3.3.0-alpha.6",
+  "version": "3.3.0-rc.0",
   "description": "A library for querying and managing network state in Redux applications",
   "homepage": "https://github.com/amplitude/redux-query",
   "main": "dist/commonjs/index.js",

--- a/packages/redux-query/package.json
+++ b/packages/redux-query/package.json
@@ -1,6 +1,6 @@
 {
   "name": "redux-query",
-  "version": "3.3.0-alpha.4",
+  "version": "3.3.0-alpha.5",
   "description": "A library for querying and managing network state in Redux applications",
   "homepage": "https://github.com/amplitude/redux-query",
   "main": "dist/commonjs/index.js",

--- a/packages/redux-query/package.json
+++ b/packages/redux-query/package.json
@@ -1,6 +1,6 @@
 {
   "name": "redux-query",
-  "version": "3.3.0-alpha.5",
+  "version": "3.3.0-alpha.6",
   "description": "A library for querying and managing network state in Redux applications",
   "homepage": "https://github.com/amplitude/redux-query",
   "main": "dist/commonjs/index.js",

--- a/website/i18n/en.json
+++ b/website/i18n/en.json
@@ -64,6 +64,9 @@
       },
       "use-request": {
         "title": "useRequest"
+      },
+      "use-requests": {
+        "title": "useRequests"
       }
     },
     "links": {

--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -10,7 +10,7 @@
       "network-interfaces"
     ],
     "Redux API": ["redux-actions", "redux-selectors"],
-    "React API": ["use-request", "use-mutation", "connect-request"],
+    "React API": ["use-request", "use-requests", "use-mutation", "connect-request"],
     "Examples": ["examples/simple", "examples/hacker-news"],
     "Upgrade Guides": ["upgrade-guides/v1-to-v2", "upgrade-guides/v2-to-v3"],
     "Other": ["flow", "typescript", "contributing"]


### PR DESCRIPTION
## Description
`useRequests` is a react hook that takes in an array of query configs and returns two values. The first is an object containing values `isFinished` and `isPending`. `isPending` is true as long as **any** of the network calls made by `useRequests` is still in progress. `isFinished` is false as long **all** requests have not finished. The other value returned is a refresh function. This function when called forces all requests to be recalled no matter the response or status of the previous call.

## Upgrade
This is meant to be a replacement to the v2 mapPropsToConfig functionality. Redux Query React did not have a good way of making batch requests in v3. 

## Architecture
This PR mostly copies both the current `useRequest` and v2 `connect-request` to make a hook for an array of query configs.

## Feature Request
https://github.com/amplitude/redux-query/issues/158