### PR TITLE
fix(redux-query-react): Add useRequests and fix other typings

### DIFF
--- a/packages/redux-query-react/index.d.ts
+++ b/packages/redux-query-react/index.d.ts
@@ -28,12 +28,12 @@ declare module 'redux-query-react' {
   ) => React.ComponentType<Omit<TProps, 'forceRequest'>>;
 
   export type RequestConnector = <
-    TProps extends WithForceRequest<TEntities> = WithForceRequest<TEntities>,
-    TEntities = Entities
+    TEntities = Entities,
+    TProps extends WithForceRequest<TEntities> = WithForceRequest<TEntities>
   >(
     mapPropsToConfigs: QueryConfigsFactory<TEntities>,
     options?: ConnectRequestOptions,
-  ) => ConnectRequestWrapper<TProps, TEntities>;
+  ) => ConnectRequestWrapper<TProps>;
 
   export interface ProviderProps {
     queriesSelector: QueriesSelector;
@@ -48,8 +48,12 @@ declare module 'redux-query-react' {
   export type UseRequestsHook = <TEntities>(
     queryConfigs: Array<QueryConfig<TEntities>> | null | undefined,
   ) => [QueryState, ForceRequestCallback<TEntities>];
-  export type MutationQueryConfigFactory = <TEntities>(...args: any) => QueryConfig<TEntities>;
-  export type RunMutation = <TEntities>(...args: any) => Promise<ActionPromiseValue<TEntities>>;
+  export type MutationQueryConfigFactory<TEntities> = <TEntities>(
+    ...args: any
+  ) => QueryConfig<TEntities>;
+  export type RunMutation<TEntities> = <TEntities>(
+    ...args: any
+  ) => Promise<ActionPromiseValue<TEntities>>;
   export type UseMutationHook = <TEntities>(
     createQueryConfig: MutationQueryConfigFactory<TEntities>,
   ) => [QueryState, RunMutation<TEntities>];

--- a/packages/redux-query-react/index.d.ts
+++ b/packages/redux-query-react/index.d.ts
@@ -43,10 +43,10 @@ declare module 'redux-query-react' {
   export type ReduxQueryProvider = React.ComponentType<ProviderProps>;
   export type ActionPromise<TEntities> = Promise<ActionPromiseValue<TEntities>> | undefined;
   export type UseRequestHook = <TEntities>(
-    queryConfig: QueryConfig<TEntities>,
+    queryConfig: QueryConfig<TEntities> | null | undefined,
   ) => [QueryState, ForceRequestCallback<TEntities>];
   export type UseRequestsHook = <TEntities>(
-    queryConfigs: Array<QueryConfig<TEntities>> | null | undefined,
+    queryConfigs: Array<QueryConfig<TEntities> | null | undefined> | null | undefined,
   ) => [QueryState, ForceRequestCallback<TEntities>];
   export type MutationQueryConfigFactory<TEntities> = <TEntities>(
     ...args: any

--- a/packages/redux-query-react/index.d.ts
+++ b/packages/redux-query-react/index.d.ts
@@ -10,7 +10,9 @@ declare module 'redux-query-react' {
   } from 'redux-query';
 
   export type QueryConfigFactory<TEntities> = (...args: any[]) => QueryConfig<TEntities>;
-  export type QueryConfigsFactory<TEntities> = (...args: any[]) => QueryConfig<TEntities> | QueryConfig<TEntities>[];
+  export type QueryConfigsFactory<TEntities> = (
+    ...args: any[]
+  ) => QueryConfig<TEntities> | QueryConfig<TEntities>[];
 
   export interface ConnectRequestOptions {
     forwardRef?: boolean;
@@ -25,7 +27,10 @@ declare module 'redux-query-react' {
     WrappedComponent: React.ComponentType<TProps>,
   ) => React.ComponentType<Omit<TProps, 'forceRequest'>>;
 
-  export type RequestConnector = <TProps extends WithForceRequest<TEntities> = WithForceRequest<TEntities>, TEntities = Entities>(
+  export type RequestConnector = <
+    TProps extends WithForceRequest<TEntities> = WithForceRequest<TEntities>,
+    TEntities = Entities
+  >(
     mapPropsToConfigs: QueryConfigsFactory<TEntities>,
     options?: ConnectRequestOptions,
   ) => ConnectRequestWrapper<TProps, TEntities>;
@@ -37,7 +42,12 @@ declare module 'redux-query-react' {
 
   export type ReduxQueryProvider = React.ComponentType<ProviderProps>;
   export type ActionPromise<TEntities> = Promise<ActionPromiseValue<TEntities>> | undefined;
-  export type UseRequestHook = <TEntities>(queryConfig: QueryConfig<TEntities>) => [QueryState, ForceRequestCallback<TEntities>];
+  export type UseRequestHook = <TEntities>(
+    queryConfig: QueryConfig<TEntities>,
+  ) => [QueryState, ForceRequestCallback<TEntities>];
+  export type UseRequestsHook = <TEntities>(
+    queryConfigs: Array<QueryConfig<TEntities>> | null | undefined,
+  ) => [QueryState, ForceRequestCallback<TEntities>];
   export type MutationQueryConfigFactory = <TEntities>(...args: any) => QueryConfig<TEntities>;
   export type RunMutation = <TEntities>(...args: any) => Promise<ActionPromiseValue<TEntities>>;
   export type UseMutationHook = <TEntities>(
@@ -47,5 +57,6 @@ declare module 'redux-query-react' {
   export const connectRequest: RequestConnector;
   export const Provider: ReduxQueryProvider;
   export const useRequest: UseRequestHook;
+  export const useRequests: UseRequestsHook;
   export const useMutation: UseMutationHook;
 }

--- a/packages/redux-query-react/yarn.lock
+++ b/packages/redux-query-react/yarn.lock
@@ -1434,6 +1434,11 @@ babel-preset-jest@^24.6.0:
     "@babel/plugin-syntax-object-rest-spread" "^7.0.0"
     babel-plugin-jest-hoist "^24.6.0"
 
+backo@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/backo/-/backo-1.1.0.tgz#a36c4468923f2d265c9e8a709ea56ecdaff807e6"
+  integrity sha1-o2xEaJI/LSZcnopwnqVuza/4B+Y=
+
 balanced-match@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.0.tgz#89b4d199ab2bee49de164ea02b89ce462d71b767"
@@ -3062,6 +3067,11 @@ iconv-lite@0.4.24, iconv-lite@^0.4.24, iconv-lite@^0.4.4:
   dependencies:
     safer-buffer ">= 2.1.2 < 3"
 
+idx@^2.5.6:
+  version "2.5.6"
+  resolved "https://registry.yarnpkg.com/idx/-/idx-2.5.6.tgz#1f824595070100ae9ad585c86db08dc74f83a59d"
+  integrity sha512-WFXLF7JgPytbMgelpRY46nHz5tyDcedJ76pLV+RJWdb8h33bxFq4bdZau38DhNSzk5eVniBf1K3jwfK+Lb5nYA==
+
 ieee754@^1.1.4:
   version "1.1.13"
   resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.1.13.tgz#ec168558e95aa181fd87d37f55c32bbcb6708b84"
@@ -3157,7 +3167,7 @@ interpret@^1.1.0:
   resolved "https://registry.yarnpkg.com/interpret/-/interpret-1.2.0.tgz#d5061a6224be58e8083985f5014d844359576296"
   integrity sha512-mT34yGKMNceBQUoVn7iCDKDntA7SC6gycMAWzGx1z/CMCTV7b2AAtXlo3nRyHZ1FelRkQbQjprHSYGwzLtkVbw==
 
-invariant@^2.2.2, invariant@^2.2.4:
+invariant@^2.2.0, invariant@^2.2.2, invariant@^2.2.4:
   version "2.2.4"
   resolved "https://registry.yarnpkg.com/invariant/-/invariant-2.2.4.tgz#610f3c92c9359ce1db616e538008d23ff35158e6"
   integrity sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==
@@ -3864,6 +3874,13 @@ json-stable-stringify-without-jsonify@^1.0.1:
   resolved "https://registry.yarnpkg.com/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz#9db7b59496ad3f3cfef30a75142d2d930ad72651"
   integrity sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=
 
+json-stable-stringify@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz#9a759d39c5f2ff503fd5300646ed445f88c4f9af"
+  integrity sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=
+  dependencies:
+    jsonify "~0.0.0"
+
 json-stringify-safe@~5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz#1296a2d58fd45f19a0f6ce01d65701e2c735b6eb"
@@ -3882,6 +3899,11 @@ json5@^2.1.0:
   integrity sha512-8Mh9h6xViijj36g7Dxi+Y4S6hNGV96vcJZr/SrlHh1LR/pEn/8j/+qIBbs44YKl69Lrfctp4QD+AdWLTMqEZAQ==
   dependencies:
     minimist "^1.2.0"
+
+jsonify@~0.0.0:
+  version "0.0.0"
+  resolved "https://registry.yarnpkg.com/jsonify/-/jsonify-0.0.0.tgz#2c74b6ee41d93ca51b7b5aaee8f503631d252a73"
+  integrity sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=
 
 jsprim@^1.2.2:
   version "1.4.1"
@@ -5220,6 +5242,16 @@ realpath-native@^1.1.0:
   integrity sha512-wlgPA6cCIIg9gKz0fgAPjnzh4yR/LnXovwuo9hvyGvx3h8nX4+/iLZplfUWasXpqD8BdnGnP5njOFjkUwPzvjA==
   dependencies:
     util.promisify "^1.0.0"
+
+redux-query@^3.3.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/redux-query/-/redux-query-3.3.0.tgz#b62b527666739a7a3a76a0aa6470d3b087c76af3"
+  integrity sha512-jS+H/4P3r9FE2+rG9KljR7t2HxYlgD6TsO8uXUMHAW7bjvtQCNj3ISCu2+BzZybDCEBR5JYm4fXUw6W3eigHSg==
+  dependencies:
+    backo "^1.1.0"
+    idx "^2.5.6"
+    invariant "^2.2.0"
+    json-stable-stringify "^1.0.0"
 
 redux@^4.0.1:
   version "4.0.1"


### PR DESCRIPTION
Related #158 

## Changes

- feat(redux-query-react): Add `useRequests` export and `UseRequests` typing
- fix(redux-query-react): Fix TS errors in `index.d.ts`
- fix(redux-query-react): Query configs should be optional

## Notes

In `use-request` and `use-requests`, it looks like query configs are a `Maybe` type (to allow ignoring a query) which is useful but wasn't reflected in the TS typings, so I added that.

There are some broken typings that fallback to `any` inside an editor, as seen here:

![image](https://user-images.githubusercontent.com/563819/71922816-4d775680-3151-11ea-8b65-2c6fbf2a38ed.png)

If you are using TS to consume the package, the build will fail, so I think these should be fixed.

![image](https://user-images.githubusercontent.com/563819/71925137-00e24a00-3156-11ea-9d28-ac3c6d7ca181.png)
