### PR TITLE
fix(redux-query-react): fix finishedCallback

### DIFF
--- a/packages/redux-query-react/src/components/connect-request.js
+++ b/packages/redux-query-react/src/components/connect-request.js
@@ -88,9 +88,11 @@ const useMultiRequest = <Config>(mapPropsToConfigs: MapPropsToConfigs<Config>, p
     }
   });
 
-  const finishedCallback = useConstCallback(() => {
-    (queryKey: QueryKey) => {
-      pendingRequests.current.delete(queryKey);
+  const finishedCallback = useConstCallback((queryKey: ?QueryKey) => {
+    return () => {
+      if (queryKey != null) {
+        pendingRequests.current.delete(queryKey);
+      }
     };
   });
 
@@ -98,7 +100,7 @@ const useMultiRequest = <Config>(mapPropsToConfigs: MapPropsToConfigs<Config>, p
     (queryConfig: ?QueryConfig): ?QueryConfig => {
       return {
         ...queryConfig,
-        unstable_preDispatchCallback: finishedCallback,
+        unstable_preDispatchCallback: finishedCallback(getQueryKey(queryConfig)),
         retry: true,
       };
     },

--- a/packages/redux-query-react/src/hooks/use-requests.js
+++ b/packages/redux-query-react/src/hooks/use-requests.js
@@ -81,9 +81,11 @@ const useRequests = (
     }
   });
 
-  const finishedCallback = useConstCallback(() => {
-    (queryKey: QueryKey) => {
-      pendingRequests.current.delete(queryKey);
+  const finishedCallback = useConstCallback((queryKey: ?QueryKey) => {
+    return () => {
+      if (queryKey != null) {
+        pendingRequests.current.delete(queryKey);
+      }
     };
   });
 
@@ -91,7 +93,7 @@ const useRequests = (
     (queryConfig: ?QueryConfig): ?QueryConfig => {
       return {
         ...queryConfig,
-        unstable_preDispatchCallback: finishedCallback,
+        unstable_preDispatchCallback: finishedCallback(getQueryKey(queryConfig)),
         retry: true,
       };
     },


### PR DESCRIPTION
https://github.com/amplitude/redux-query/issues/158#issuecomment-572334306 fix `finishedCallback` to dismiss console warning:  `Trying to cancel a request that is not in flight:`