### PR TITLE
useMutation hooks now has lazy loaded callbacks.

### DIFF
--- a/docs/use-mutation.md
+++ b/docs/use-mutation.md
@@ -74,3 +74,14 @@ const Comment = () => {
   );
 };
 ```
+
+Also the `useMutation` callback accepts **async functions**, this is helpful when we need to create **body** based off another api call or any async function:
+
+### Example
+
+```javascript
+const [props, mutate] = useMutation(async values => ({
+  url: '/api',
+  body: await myAsyncFn(values),
+}));
+```

--- a/packages/redux-query-react/src/hooks/use-mutation.js
+++ b/packages/redux-query-react/src/hooks/use-mutation.js
@@ -22,8 +22,8 @@ const useMutation = (
   const queryState = useQueryState(queryConfig);
 
   const mutate = React.useCallback(
-    (...args) => {
-      const queryConfig = makeQueryConfig(...args);
+    async (...args) => {
+      const queryConfig = await makeQueryConfig(...args);
 
       setQueryConfig(queryConfig);
 


### PR DESCRIPTION
Helpful for situations when we need to create body based off another async calls.

### Example:

```
const [state, onMutate] = useMutation<Entities>(async (data: Data) => ({
    url: '/api',
    body: await myPromiseCall(),
  }));
```

