### PR TITLE
Update typescript typings

### DIFF
--- a/packages/redux-query-react/index.d.ts
+++ b/packages/redux-query-react/index.d.ts
@@ -9,28 +9,32 @@ declare module 'redux-query-react' {
     QueriesSelector,
   } from 'redux-query';
 
-  export type QueryConfigFactory<TEntities> = (...args: any[]) => QueryConfig<TEntities>;
-  export type QueryConfigsFactory<TEntities> = (
-    ...args: any[]
+  export type QueryConfigFactory<TEntities = Entities, TArgs = never> = (
+    ...args: TArgs
+  ) => QueryConfig<TEntities>;
+  export type QueryConfigsFactory<TEntities = Entities, TArgs = never> = (
+    ...args: TArgs
   ) => QueryConfig<TEntities> | QueryConfig<TEntities>[];
 
   export interface ConnectRequestOptions {
     forwardRef?: boolean;
     pure?: boolean;
   }
-  export type ForceRequestCallback<TEntities> = () => Promise<ActionPromiseValue<TEntities>>;
-  export interface WithForceRequest<TEntities> {
+  export type ForceRequestCallback<TEntities = Entities> = () => Promise<
+    ActionPromiseValue<TEntities>
+  >;
+  export interface WithForceRequest<TEntities = Entities> {
     forceRequest: ForceRequestCallback<TEntities>;
   }
 
-  export type ConnectRequestWrapper<TProps extends WithForceRequest<any>> = (
+  export type ConnectRequestWrapper<TProps extends WithForceRequest> = (
     WrappedComponent: React.ComponentType<TProps>,
   ) => React.ComponentType<Omit<TProps, 'forceRequest'>>;
 
-  export type RequestConnector = <
+  export type RequestConnector<
     TEntities = Entities,
     TProps extends WithForceRequest<TEntities> = WithForceRequest<TEntities>
-  >(
+  > = (
     mapPropsToConfigs: QueryConfigsFactory<TEntities>,
     options?: ConnectRequestOptions,
   ) => ConnectRequestWrapper<TProps>;
@@ -39,24 +43,26 @@ declare module 'redux-query-react' {
     queriesSelector: QueriesSelector;
     children?: React.ReactNode;
   }
-
   export type ReduxQueryProvider = React.ComponentType<ProviderProps>;
-  export type ActionPromise<TEntities> = Promise<ActionPromiseValue<TEntities>> | undefined;
-  export type UseRequestHook = <TEntities>(
+
+  export type ActionPromise<TEntities = Entities> =
+    | Promise<ActionPromiseValue<TEntities>>
+    | undefined;
+  type RunMutation<TEntities = Entities, TArgs = never> = (
+    ...args: TArgs
+  ) => ActionPromise<TEntities>;
+
+  export type UseRequestHook = <TEntities = Entities>(
     queryConfig: QueryConfig<TEntities> | null | undefined,
   ) => [QueryState, ForceRequestCallback<TEntities>];
-  export type UseRequestsHook = <TEntities>(
+
+  export type UseRequestsHook = <TEntities = Entities>(
     queryConfigs: Array<QueryConfig<TEntities> | null | undefined> | null | undefined,
   ) => [QueryState, ForceRequestCallback<TEntities>];
-  export type MutationQueryConfigFactory<TEntities> = <TEntities>(
-    ...args: any
-  ) => QueryConfig<TEntities>;
-  export type RunMutation<TEntities> = <TEntities>(
-    ...args: any
-  ) => Promise<ActionPromiseValue<TEntities>>;
-  export type UseMutationHook = <TEntities>(
-    createQueryConfig: MutationQueryConfigFactory<TEntities>,
-  ) => [QueryState, RunMutation<TEntities>];
+
+  export type UseMutationHook = <TEntities = Entities, TArgs = never>(
+    createQueryConfig: QueryConfigFactory<TEntities, TArgs>,
+  ) => [QueryState, RunMutation<TEntities, TArgs>];
 
   export const connectRequest: RequestConnector;
   export const Provider: ReduxQueryProvider;

--- a/packages/redux-query-react/index.d.ts
+++ b/packages/redux-query-react/index.d.ts
@@ -66,7 +66,4 @@ declare module 'redux-query-react' {
 
   export const connectRequest: RequestConnector;
   export const Provider: ReduxQueryProvider;
-  export const useRequest: UseRequestHook;
-  export const useRequests: UseRequestsHook;
-  export const useMutation: UseMutationHook;
 }

--- a/packages/redux-query/index.d.ts
+++ b/packages/redux-query/index.d.ts
@@ -25,14 +25,7 @@ declare module 'redux-query' {
   }
   export type EntitiesState = Entities;
 
-  export type KnownHttpMethods =
-    | 'GET'
-    | 'HEAD'
-    | 'PUT'
-    | 'POST'
-    | 'DELETE'
-    | 'PATCH'
-    | 'OPTIONS';
+  export type KnownHttpMethods = 'GET' | 'HEAD' | 'PUT' | 'POST' | 'DELETE' | 'PATCH' | 'OPTIONS';
   export type HttpMethods = KnownHttpMethods | string;
 
   export const httpMethods: { [k in KnownHttpMethods]: KnownHttpMethods };
@@ -46,16 +39,16 @@ declare module 'redux-query' {
   export type RollbackStrategy<T> = (initialValue: T, currentValue: T) => T;
 
   export type Update<TEntities = Entities> = {
-    [K in keyof TEntities]?: UpdateStrategy<TEntities[K]>;
-  }
+    [K in keyof TEntities]?: UpdateStrategy<TEntities[K]>
+  };
 
   export type OptimisticUpdate<TEntities = Entities> = {
-    [K in keyof TEntities]?: OptimisticUpdateStrategy<TEntities[K]>;
-  }
+    [K in keyof TEntities]?: OptimisticUpdateStrategy<TEntities[K]>
+  };
 
   export type Rollback<TEntities = Entities> = {
-    [K in keyof TEntities]?: RollbackStrategy<TEntities[K]>;
-  }
+    [K in keyof TEntities]?: RollbackStrategy<TEntities[K]>
+  };
 
   export interface WithTime {
     time: number;
@@ -69,7 +62,8 @@ declare module 'redux-query' {
     update: Update<TEntities>;
   }
 
-  export type RequestAsyncAction<TEntities = Entities> = Action<'@@query/REQUEST_ASYNC'> & QueryConfig<TEntities>;
+  export type RequestAsyncAction<TEntities = Entities> = Action<'@@query/REQUEST_ASYNC'> &
+    QueryConfig<TEntities>;
 
   export interface QueryStartParams {
     body?: RequestBody;
@@ -95,11 +89,17 @@ declare module 'redux-query' {
     url: Url;
   }
 
-  export type RequestSuccessAction<TEntities = Entities> = Action<'@@query/REQUEST_SUCCESS'> | QueryResponse<TEntities> | WithTime;
-  export type RequestFailureAction<TEntities = Entities> = Action<'@@query/REQUEST_FAILURE'> | QueryResponse<TEntities> | WithTime;
-  export type MutateAsyncAction<TEntities = Entities> = Action<'@@query/MUTATE_ASYNC'> & QueryConfig<TEntities>;
+  export type RequestSuccessAction<TEntities = Entities> = Action<'@@query/REQUEST_SUCCESS'> &
+    QueryResponse<TEntities> &
+    WithTime;
+  export type RequestFailureAction<TEntities = Entities> = Action<'@@query/REQUEST_FAILURE'> &
+    QueryResponse<TEntities> &
+    WithTime;
+  export type MutateAsyncAction<TEntities = Entities> = Action<'@@query/MUTATE_ASYNC'> &
+    QueryConfig<TEntities>;
   export type MutateSuccessAction = Action<'@@query/MUTATE_SUCCESS'> & QueryResponse;
-  export type UpdateEntitiesAction<TEntities = Entities> = Action<'@@query/UPDATE_ENTITIES'> & WithUpdateEntities<TEntities>;
+  export type UpdateEntitiesAction<TEntities = Entities> = Action<'@@query/UPDATE_ENTITIES'> &
+    WithUpdateEntities<TEntities>;
   export type CancelQueryAction = Action<'@@query/CANCEL_QUERY'> & WithQueryKey;
   export type ReduxQueryAction<TEntities = Entities> =
     | RequestAsyncAction<TEntities>
@@ -173,9 +173,13 @@ declare module 'redux-query' {
 
   export type QueriesSelector<TState = any> = (state: TState) => QueriesState;
 
-  export type EntitiesSelector<TEntities = EntitiesState, TState = any> = (state: TState) => TEntities;
+  export type EntitiesSelector<TEntities = EntitiesState, TState = any> = (
+    state: TState,
+  ) => TEntities;
 
-  export type QueryKeyBuilder<TEntities = Entities> = (queryConfig?: QueryConfig<TEntities>) => QueryKey | undefined;
+  export type QueryKeyBuilder<TEntities = Entities> = (
+    queryConfig?: QueryConfig<TEntities>,
+  ) => QueryKey | undefined;
 
   export interface QueryState {
     headers?: ResponseHeaders;
@@ -211,9 +215,18 @@ declare module 'redux-query' {
     };
     retryableStatusCodes: ResponseStatus[];
   }
-  export type QueriesReducer<TEntities = EntitiesState> = Reducer<QueriesState, ReduxQueryAction<TEntities>>;
-  export type EntitiesReducer<TEntities = EntitiesState> = Reducer<TEntities, ReduxQueryAction<TEntities>>;
-  export type ErrorsReducer<TEntities = EntitiesState> = Reducer<ErrorsState, ReduxQueryAction<TEntities>>;
+  export type QueriesReducer<TEntities = EntitiesState> = Reducer<
+    QueriesState,
+    ReduxQueryAction<TEntities>
+  >;
+  export type EntitiesReducer<TEntities = EntitiesState> = Reducer<
+    TEntities,
+    ReduxQueryAction<TEntities>
+  >;
+  export type ErrorsReducer<TEntities = EntitiesState> = Reducer<
+    ErrorsState,
+    ReduxQueryAction<TEntities>
+  >;
   export type QueryMiddlewareFactory = <TEntities = EntitiesState, TState = any>(
     networkInterface: NetworkInterface,
     queriesSelector: QueriesSelector<TState>,
@@ -228,8 +241,14 @@ declare module 'redux-query' {
   export const querySelectors: {
     isFinished: (queriesState: QueriesState, queryConfig: QueryConfig<any>) => boolean;
     isPending: (queriesState: QueriesState, queryConfig: QueryConfig<any>) => boolean;
-    status: (queriesState: QueriesState, queryConfig: QueryConfig<any>) => ResponseStatus | undefined;
-    headers: (queriesState: QueriesState, queryConfig: QueryConfig<any>) => ResponseHeaders | undefined;
+    status: (
+      queriesState: QueriesState,
+      queryConfig: QueryConfig<any>,
+    ) => ResponseStatus | undefined;
+    headers: (
+      queriesState: QueriesState,
+      queryConfig: QueryConfig<any>,
+    ) => ResponseHeaders | undefined;
     lastUpdated: (queriesState: QueriesState, queryConfig: QueryConfig<any>) => number | undefined;
     queryCount: (queriesState: QueriesState, queryConfig: QueryConfig<any>) => number;
   };
@@ -254,8 +273,13 @@ declare module 'redux-query' {
   };
 
   export const queryMiddleware: QueryMiddlewareFactory;
-  export interface ReduxQueryDispatch<TEntities = Entities, A extends AnyAction = ReduxQueryAction<TEntities>> {
-    <T extends ReduxQueryAction<TEntities>>(action: ReduxQueryAction<TEntities>): Promise<ActionPromiseValue<TEntities>>;
+  export interface ReduxQueryDispatch<
+    TEntities = Entities,
+    A extends AnyAction = ReduxQueryAction<TEntities>
+  > {
+    <T extends ReduxQueryAction<TEntities>>(action: ReduxQueryAction<TEntities>): Promise<
+      ActionPromiseValue<TEntities>
+    >;
     <T extends A>(action: T): T;
   }
 }


### PR DESCRIPTION
this PR fixes the incompatible type errors in #170 

```typescript
const [, runMutation] = useMutation((id: string) => someConfigFactory(id))

runMutation(1) // should error out because of incompatible types
runMutation('some id') // no errors
```

...plus fixes to action types `RequestSuccess` and `RequestFailure` types.

This is tested on Typescript ver. 3.8.2
