### PR TITLE
Introduce useRequestOnDemand hook

### DIFF
--- a/packages/redux-query-react/flow-test/hooks/use-request-on-demand.js
+++ b/packages/redux-query-react/flow-test/hooks/use-request-on-demand.js
@@ -1,0 +1,25 @@
+// @flow
+
+import * as React from 'react';
+
+import useRequestOnDemand from '../../src/hooks/use-request-on-demand';
+
+const Card = () => {
+  const [{ isPending }, request] = useRequestOnDemand((force: boolean) => ({
+    url: '/api',
+    force,
+  }));
+
+  return (
+    <div>
+      {isPending === true ? 'loading…' : 'loaded'}
+      {/* $FlowFixMe expected */}
+      <button onClick={() => request('false')}>Trigger</button>
+      <button onClick={() => request(true)}>Trigger</button>
+    </div>
+  );
+};
+
+export const App = () => {
+  return <Card />;
+};

--- a/packages/redux-query-react/index.d.ts
+++ b/packages/redux-query-react/index.d.ts
@@ -53,6 +53,10 @@ declare module 'redux-query-react' {
     ...args: TArgs
   ) => ActionPromise<TEntities>;
 
+  type RunRequest<TEntities = Entities, TArgs = never> = (
+    ...args: TArgs
+  ) => ActionPromise<TEntities>;
+
   export type UseRequestHook = <TEntities = Entities>(
     queryConfig: QueryConfig<TEntities> | null | undefined,
   ) => [QueryState, ForceRequestCallback<TEntities>];
@@ -61,6 +65,10 @@ declare module 'redux-query-react' {
     queryConfigs: Array<QueryConfig<TEntities> | null | undefined> | null | undefined,
   ) => [QueryState, ForceRequestsCallback];
 
+  export type UseRequestOnDemandHook = <TEntities = Entities, TArgs = never>(
+    createQueryConfig: QueryConfigFactory<TEntities, TArgs>,
+  ) => [QueryState, RunRequest<TEntities, TArgs>];
+
   export type UseMutationHook = <TEntities = Entities, TArgs = never>(
     createQueryConfig: QueryConfigFactory<TEntities, TArgs>,
   ) => [QueryState, RunMutation<TEntities, TArgs>];
@@ -68,6 +76,7 @@ declare module 'redux-query-react' {
   export const connectRequest: RequestConnector;
   export const Provider: ReduxQueryProvider;
   export const useRequest: UseRequestHook;
+  export const useRequestOnDemand: UseRequestOnDemandHook;
   export const useRequests: UseRequestsHook;
   export const useMutation: UseMutationHook;
 }

--- a/packages/redux-query-react/src/hooks/use-request-on-demand.js
+++ b/packages/redux-query-react/src/hooks/use-request-on-demand.js
@@ -1,0 +1,38 @@
+// @flow
+
+// NOTE(kelson): The public flow type interface for this hook is defined in use-request-on-demand.js.flow
+
+import * as React from 'react';
+import { useDispatch } from 'react-redux';
+import { requestAsync } from 'redux-query';
+import type { ActionPromiseValue, QueryConfig } from 'redux-query/types.js.flow';
+
+import type { QueryState } from '../types';
+import useQueryState from './use-query-state';
+
+const useRequestOnDemand = (
+  makeQueryConfig: (...args: $ReadOnlyArray<mixed>) => QueryConfig,
+): [QueryState, (...args: $ReadOnlyArray<mixed>) => Promise<ActionPromiseValue>] => {
+  const reduxDispatch = useDispatch();
+
+  // This query config and query state are driven based off of the callback – so they represent
+  // the query config that was used for the most-recent request callback.
+  const [queryConfig, setQueryConfig] = React.useState(null);
+
+  const queryState = useQueryState(queryConfig);
+
+  const request = React.useCallback(
+    (...args: $ReadOnlyArray<mixed>) => {
+      const queryConfig = makeQueryConfig(...args);
+
+      setQueryConfig(queryConfig);
+
+      return reduxDispatch(requestAsync(queryConfig));
+    },
+    [makeQueryConfig, reduxDispatch],
+  );
+
+  return [queryState, request];
+};
+
+export default useRequestOnDemand;

--- a/packages/redux-query-react/src/hooks/use-request-on-demand.js.flow
+++ b/packages/redux-query-react/src/hooks/use-request-on-demand.js.flow
@@ -1,0 +1,14 @@
+// @flow
+
+import type { ActionPromiseValue, QueryConfig } from 'redux-query/types.js.flow';
+
+import type { QueryState } from '../types';
+
+// This flow type declaration enables proper typechecking on each of the arguments. So this fails:
+// ```
+// const [, request] = useRequestOnDemand((myBool: boolean) => makeMyQueryConfig(myBool));
+// request('a atring');
+// ``
+declare export default function useRequestOnDemand<T: $ReadOnlyArray<mixed>>(
+  callback: (...args: T) => QueryConfig,
+): [QueryState, (...args: T) => Promise<ActionPromiseValue>];

--- a/packages/redux-query-react/src/index.js
+++ b/packages/redux-query-react/src/index.js
@@ -4,10 +4,12 @@ import connectRequest from './components/connect-request';
 import Provider from './components/Provider';
 import useMutation from './hooks/use-mutation';
 import useRequest from './hooks/use-request';
+import useRequestOnDemand from './hooks/use-request-on-demand';
 import useRequests from './hooks/use-requests';
 
 export { connectRequest };
 export { Provider };
 export { useMutation };
 export { useRequest };
+export { useRequestOnDemand };
 export { useRequests };

--- a/packages/redux-query-react/test/hooks/use-request-on-demand.test.js
+++ b/packages/redux-query-react/test/hooks/use-request-on-demand.test.js
@@ -1,0 +1,180 @@
+import * as React from 'react';
+import { render, waitForElement, getByTestId, fireEvent } from '@testing-library/react';
+import { Provider, useSelector } from 'react-redux';
+import { applyMiddleware, createStore, combineReducers } from 'redux';
+import { entitiesReducer, queriesReducer, queryMiddleware } from 'redux-query';
+
+import useRequestOnDemand from '../../src/hooks/use-request-on-demand';
+import ReduxQueryProvider from '../../src/components/Provider';
+
+export const getQueries = state => state.queries;
+export const getEntities = state => state.entities;
+
+const reducer = combineReducers({
+  entities: entitiesReducer,
+  queries: queriesReducer,
+});
+
+const artificialNetworkDelay = 100;
+
+const mockNetworkInterface = (url, method, { body: requestBody }) => {
+  let timeoutId = null;
+
+  return {
+    abort() {
+      clearTimeout(timeoutId);
+    },
+    execute(callback) {
+      if (url === '/echo') {
+        timeoutId = setTimeout(() => {
+          const status = 200;
+          const body = {
+            message: requestBody.value,
+          };
+          const text = JSON.stringify(body);
+          const headers = {};
+
+          callback(null, status, body, text, headers);
+        }, artificialNetworkDelay);
+      } else {
+        timeoutId = setTimeout(() => {
+          callback(null, 404, {}, '{}', {});
+        }, artificialNetworkDelay);
+      }
+    },
+  };
+};
+
+let store;
+
+const App = props => {
+  return (
+    <Provider store={store}>
+      <ReduxQueryProvider queriesSelector={getQueries}>{props.children}</ReduxQueryProvider>
+    </Provider>
+  );
+};
+
+describe('useRequestOnDemand', () => {
+  beforeEach(() => {
+    store = createStore(
+      reducer,
+      applyMiddleware(queryMiddleware(mockNetworkInterface, getQueries, getEntities)),
+    );
+  });
+
+  it('loads data initially and supports refresh', async () => {
+    const Content = () => {
+      const [{ isPending }, request] = useRequestOnDemand(() => ({
+        url: '/echo',
+        body: {
+          value: 'BodyValue',
+        },
+        update: {
+          message: (prevValue, newValue) => newValue,
+        },
+      }));
+      const message = useSelector(state => state.entities.message);
+
+      return (
+        <div>
+          {message ? (
+            <div data-testid="loaded-content">{message}</div>
+          ) : (
+            <div data-testid="empty-state">empty</div>
+          )}
+          {isPending && <div data-testid="loading-content">loading</div>}
+          <button data-testid="submit-button" onClick={request}>
+            submit
+          </button>
+        </div>
+      );
+    };
+
+    const { container } = render(
+      <App>
+        <Content />
+      </App>,
+    );
+
+    // Loaded
+
+    let emptyStateNode = getByTestId(container, 'empty-state');
+    expect(emptyStateNode.textContent).toBe('empty');
+
+    // Click submit button
+
+    let buttonNode = getByTestId(container, 'submit-button');
+    fireEvent.click(buttonNode);
+
+    // We're in a loading state now
+
+    let loadingContentNode = await waitForElement(() => getByTestId(container, 'loading-content'));
+    expect(loadingContentNode.textContent).toBe('loading');
+
+    // Mutation finished, message should be visible
+
+    let loadedContentNode = await waitForElement(() => getByTestId(container, 'loaded-content'));
+    expect(loadedContentNode.textContent).toBe('BodyValue');
+  });
+
+  it('supplies a callback that returns a promise', async () => {
+    const Content = () => {
+      const [message, setMessage] = React.useState(null);
+
+      const [{ isPending }, request] = useRequestOnDemand(() => ({
+        url: '/echo',
+        body: {
+          value: 'BodyValue',
+        },
+        update: {
+          message: (prevValue, newValue) => newValue,
+        },
+      }));
+
+      const onSubmit = React.useCallback(() => {
+        request().then(result => setMessage(result.body.message));
+      }, [request]);
+
+      return (
+        <div>
+          {message ? (
+            <div data-testid="loaded-content">{message}</div>
+          ) : (
+            <div data-testid="empty-state">empty</div>
+          )}
+          {isPending && <div data-testid="loading-content">loading</div>}
+          <button data-testid="submit-button" onClick={onSubmit}>
+            submit
+          </button>
+        </div>
+      );
+    };
+
+    const { container } = render(
+      <App>
+        <Content />
+      </App>,
+    );
+
+    // Loaded
+
+    let emptyStateNode = getByTestId(container, 'empty-state');
+    expect(emptyStateNode.textContent).toBe('empty');
+
+    // Click submit button
+
+    let buttonNode = getByTestId(container, 'submit-button');
+    fireEvent.click(buttonNode);
+
+    // We're in a loading state now
+
+    let loadingContentNode = await waitForElement(() => getByTestId(container, 'loading-content'));
+    expect(loadingContentNode.textContent).toBe('loading');
+
+    // Request finished, message should be visible
+
+    let loadedContentNode = await waitForElement(() => getByTestId(container, 'loaded-content'));
+    expect(loadedContentNode.textContent).toBe('BodyValue');
+  });
+});

--- a/packages/redux-query-react/test/hooks/use-request-on-demand.test.js
+++ b/packages/redux-query-react/test/hooks/use-request-on-demand.test.js
@@ -112,7 +112,7 @@ describe('useRequestOnDemand', () => {
     let loadingContentNode = await waitForElement(() => getByTestId(container, 'loading-content'));
     expect(loadingContentNode.textContent).toBe('loading');
 
-    // Mutation finished, message should be visible
+    // Request finished, message should be visible
 
     let loadedContentNode = await waitForElement(() => getByTestId(container, 'loaded-content'));
     expect(loadedContentNode.textContent).toBe('BodyValue');


### PR DESCRIPTION
This PR introduces a hook that supports:
- Making GET requests on demand via React Hook

Previously, there was no way to send a GET request on demand via React Hook (outside of component render lifecycle).

The implementation is based off of `useMutation`. The main difference is that we are just dispatching `requestAsync` under the hood.