### PR TITLE
Add `force: true` as a default for useRequestOnDemand callback

### DIFF
--- a/packages/redux-query-react/flow-test/hooks/use-request-on-demand.js
+++ b/packages/redux-query-react/flow-test/hooks/use-request-on-demand.js
@@ -5,7 +5,7 @@ import * as React from 'react';
 import useRequestOnDemand from '../../src/hooks/use-request-on-demand';
 
 const Card = () => {
-  const [{ isPending }, request] = useRequestOnDemand((force: boolean) => ({
+  const [{ isPending }, request] = useRequestOnDemand((force?: boolean) => ({
     url: '/api',
     force,
   }));
@@ -15,7 +15,9 @@ const Card = () => {
       {isPending === true ? 'loading…' : 'loaded'}
       {/* $FlowFixMe expected */}
       <button onClick={() => request('false')}>Trigger</button>
-      <button onClick={() => request(true)}>Trigger</button>
+      <button onClick={() => request()}>Trigger force = true default</button>
+      <button onClick={() => request(true)}>Trigger with force = true manually</button>
+      <button onClick={() => request(false)}>Trigger with force = false manually</button>
     </div>
   );
 };

--- a/packages/redux-query-react/src/hooks/use-request-on-demand.js
+++ b/packages/redux-query-react/src/hooks/use-request-on-demand.js
@@ -23,7 +23,12 @@ const useRequestOnDemand = (
 
   const request = React.useCallback(
     (...args: $ReadOnlyArray<mixed>) => {
-      const queryConfig = makeQueryConfig(...args);
+      const queryConfig = {
+        // Force the request to be made, even if the query state is already pending.
+        // However, allow user to override if force is passed explicitly.
+        force: true,
+        ...makeQueryConfig(...args),
+      };
 
       setQueryConfig(queryConfig);
 


### PR DESCRIPTION
Currently, if the callback to `useRequestOnDemand` is called while a request is in flight, the secondary callback will always return undefined. This update forces the query config to always force the request. Consumers can still control this behavior through their own query config.