### PR TITLE
Add support for capturing requests and responses for test data generation

### DIFF
--- a/packages/redux-query/src/lib/cookie.js
+++ b/packages/redux-query/src/lib/cookie.js
@@ -1,0 +1,11 @@
+// @flow
+
+export function getCookie(name: string) {
+  const value = `; ${document.cookie}`;
+  const parts = value.split(`; ${name}=`);
+  if (parts.length === 2)
+    return parts
+      .pop()
+      .split(';')
+      .shift();
+}

--- a/packages/redux-query/src/lib/requestsForTestData.js
+++ b/packages/redux-query/src/lib/requestsForTestData.js
@@ -1,0 +1,74 @@
+// @flow
+import type { ResponseBody, RequestBody } from '../types';
+import type { HttpMethod } from '../constants/http-methods';
+import { getCookie } from './cookie';
+
+type Requests = {
+  rest: {
+    [url: string]: {
+      method: string,
+      body: ResponseBody,
+      response: any,
+    },
+  },
+  gql: {
+    [query: string]: {
+      response: any,
+    },
+  },
+};
+
+const createBaseRequests = () => {
+  return {
+    rest: {},
+    gql: {},
+  };
+};
+
+const cookieName = 'amp_store_requests_for_test_data';
+
+export class RequestsForTestData {
+  requests: Requests = createBaseRequests();
+
+  constructor() {
+    if (this.getShouldStoreRequests()) {
+      window.getRequestsForTestData = this.getRequests;
+      window.clearRequestsForTestData = this.clearRequests;
+    }
+  }
+
+  getShouldStoreRequests = () => {
+    return getCookie(cookieName) === 'true' ? true : false;
+  };
+
+  getRequests = () => {
+    return this.requests;
+  };
+
+  clearRequests = () => {
+    this.requests = createBaseRequests();
+  };
+
+  addRequest = (url: string, body: RequestBody, method: HttpMethod, response: any) => {
+    if (this.getShouldStoreRequests()) {
+      let query = null;
+      let restUrl = url;
+      if (body && body.hasOwnProperty('query')) {
+        const bodyQuery = body.query;
+        const firstNonQueryChar =
+          bodyQuery.indexOf('(') !== -1 ? bodyQuery.indexOf('(') : bodyQuery.indexOf(' {');
+        query = bodyQuery.slice(6, firstNonQueryChar); // 6 because 'query '
+        this.requests.gql[query] = {
+          response,
+        };
+      } else {
+        restUrl = url.indexOf('?') !== -1 ? url.slice(0, url.indexOf('?')) : url;
+        this.requests.rest[restUrl] = {
+          method,
+          body,
+          response,
+        };
+      }
+    }
+  };
+}


### PR DESCRIPTION
This PR adds support for capturing requests and responses made through redux-query, for use as test data. The capturing will only occur if the cookie `amp_store_requests_for_test_data` is set to `true`. If that cookie is enabled, two functions are made available on the window:
`getRequestsForTestData` - returns the object including rest and gql requests and their responses
`clearRequestsForTestData` - resets the request object to be empty, in case the user wants to isolate request capturing to one area of the app.