### PR TITLE
Add `customQueryMiddlewareConfig` to requests/mutations

### DIFF
--- a/packages/redux-query-react/flow-test/hooks/use-request.js
+++ b/packages/redux-query-react/flow-test/hooks/use-request.js
@@ -8,7 +8,7 @@ const Card = () => {
   const [{ isPending }] = useRequest({
     url: '/api',
     customQueryMiddlewareConfig: {
-      retryableStatusCodes: [200],
+      retryableStatusCodes: [504],
     },
   });
 

--- a/packages/redux-query-react/flow-test/hooks/use-request.js
+++ b/packages/redux-query-react/flow-test/hooks/use-request.js
@@ -7,6 +7,9 @@ import useRequest from '../../src/hooks/use-request';
 const Card = () => {
   const [{ isPending }] = useRequest({
     url: '/api',
+    customQueryConfig: {
+      retryableStatusCodes: [200],
+    },
   });
 
   return <div>{isPending ? 'loading…' : 'loaded'}</div>;

--- a/packages/redux-query-react/flow-test/hooks/use-request.js
+++ b/packages/redux-query-react/flow-test/hooks/use-request.js
@@ -7,7 +7,7 @@ import useRequest from '../../src/hooks/use-request';
 const Card = () => {
   const [{ isPending }] = useRequest({
     url: '/api',
-    customQueryConfig: {
+    customQueryMiddlewareConfig: {
       retryableStatusCodes: [200],
     },
   });

--- a/packages/redux-query-react/src/components/connect-request.js
+++ b/packages/redux-query-react/src/components/connect-request.js
@@ -96,13 +96,15 @@ const useMultiRequest = <Config>(mapPropsToConfigs: MapPropsToConfigs<Config>, p
     };
   });
 
-  const transformQueryConfig = useConstCallback((queryConfig: ?QueryConfig): ?QueryConfig => {
-    return {
-      ...queryConfig,
-      unstable_preDispatchCallback: finishedCallback(getQueryKey(queryConfig)),
-      retry: true,
-    };
-  });
+  const transformQueryConfig = useConstCallback(
+    (queryConfig: ?QueryConfig): ?QueryConfig => {
+      return {
+        ...queryConfig,
+        unstable_preDispatchCallback: finishedCallback(getQueryKey(queryConfig)),
+        retry: true,
+      };
+    },
+  );
 
   // Query configs are memoized based on query key. As long as the query keys in the list don't
   // change, the query config list won't change.

--- a/packages/redux-query-react/src/components/connect-request.js
+++ b/packages/redux-query-react/src/components/connect-request.js
@@ -96,15 +96,13 @@ const useMultiRequest = <Config>(mapPropsToConfigs: MapPropsToConfigs<Config>, p
     };
   });
 
-  const transformQueryConfig = useConstCallback(
-    (queryConfig: ?QueryConfig): ?QueryConfig => {
-      return {
-        ...queryConfig,
-        unstable_preDispatchCallback: finishedCallback(getQueryKey(queryConfig)),
-        retry: true,
-      };
-    },
-  );
+  const transformQueryConfig = useConstCallback((queryConfig: ?QueryConfig): ?QueryConfig => {
+    return {
+      ...queryConfig,
+      unstable_preDispatchCallback: finishedCallback(getQueryKey(queryConfig)),
+      retry: true,
+    };
+  });
 
   // Query configs are memoized based on query key. As long as the query keys in the list don't
   // change, the query config list won't change.

--- a/packages/redux-query/index.d.ts
+++ b/packages/redux-query/index.d.ts
@@ -39,15 +39,15 @@ declare module 'redux-query' {
   export type RollbackStrategy<T> = (initialValue: T, currentValue: T) => T;
 
   export type Update<TEntities = Entities> = {
-    [K in keyof TEntities]?: UpdateStrategy<TEntities[K]>
+    [K in keyof TEntities]?: UpdateStrategy<TEntities[K]>;
   };
 
   export type OptimisticUpdate<TEntities = Entities> = {
-    [K in keyof TEntities]?: OptimisticUpdateStrategy<TEntities[K]>
+    [K in keyof TEntities]?: OptimisticUpdateStrategy<TEntities[K]>;
   };
 
   export type Rollback<TEntities = Entities> = {
-    [K in keyof TEntities]?: RollbackStrategy<TEntities[K]>
+    [K in keyof TEntities]?: RollbackStrategy<TEntities[K]>;
   };
 
   export interface WithTime {
@@ -158,6 +158,15 @@ declare module 'redux-query' {
     queryCount: number;
   };
 
+  export type QueryMiddlewareConfig = {
+    backoff: {
+      maxAttempts: number;
+      minDuration: number;
+      maxDuration: number;
+    };
+    retryableStatusCodes: Array<Status>;
+  };
+
   export interface QueryConfig<TEntities = Entities> {
     body?: RequestBody;
     force?: boolean;
@@ -171,6 +180,7 @@ declare module 'redux-query' {
     rollback?: Rollback<TEntities>;
     unstable_preDispatchCallback?: () => void;
     url: Url;
+    customQueryMiddlewareConfig?: QueryMiddlewareConfig;
   }
 
   export interface QueriesState {

--- a/packages/redux-query/src/actions/index.js
+++ b/packages/redux-query/src/actions/index.js
@@ -276,7 +276,7 @@ export const requestAsync = ({
   url,
   /* eslint-disable-next-line camelcase */
   unstable_preDispatchCallback,
-  customQueryConfig,
+  customQueryMiddlewareConfig,
 }: QueryConfig): RequestAsyncAction => {
   return {
     type: actionTypes.REQUEST_ASYNC,
@@ -290,7 +290,7 @@ export const requestAsync = ({
     update,
     url,
     unstable_preDispatchCallback,
-    customQueryConfig,
+    customQueryMiddlewareConfig,
   };
 };
 
@@ -309,7 +309,7 @@ export const mutateAsync = ({
   transform,
   update,
   url,
-  customQueryConfig,
+  customQueryMiddlewareConfig,
 }: QueryConfig): MutateAsyncAction => {
   return {
     type: actionTypes.MUTATE_ASYNC,
@@ -322,7 +322,7 @@ export const mutateAsync = ({
     transform,
     update,
     url,
-    customQueryConfig,
+    customQueryMiddlewareConfig,
   };
 };
 

--- a/packages/redux-query/src/actions/index.js
+++ b/packages/redux-query/src/actions/index.js
@@ -276,6 +276,7 @@ export const requestAsync = ({
   url,
   /* eslint-disable-next-line camelcase */
   unstable_preDispatchCallback,
+  customQueryConfig,
 }: QueryConfig): RequestAsyncAction => {
   return {
     type: actionTypes.REQUEST_ASYNC,
@@ -289,6 +290,7 @@ export const requestAsync = ({
     update,
     url,
     unstable_preDispatchCallback,
+    customQueryConfig,
   };
 };
 
@@ -307,6 +309,7 @@ export const mutateAsync = ({
   transform,
   update,
   url,
+  customQueryConfig,
 }: QueryConfig): MutateAsyncAction => {
   return {
     type: actionTypes.MUTATE_ASYNC,
@@ -319,6 +322,7 @@ export const mutateAsync = ({
     transform,
     update,
     url,
+    customQueryConfig,
   };
 };
 

--- a/packages/redux-query/src/middleware/query.js
+++ b/packages/redux-query/src/middleware/query.js
@@ -29,16 +29,8 @@ import type {
   ResponseBody,
   Status,
   Transform,
+  Config,
 } from '../types';
-
-type Config = {|
-  backoff: {|
-    maxAttempts: number,
-    minDuration: number,
-    maxDuration: number,
-  |},
-  retryableStatusCodes: Array<Status>,
-|};
 
 type ReduxStore = {|
   dispatch: (action: Action) => any,
@@ -105,7 +97,8 @@ const queryMiddleware = (
 
   return ({ dispatch, getState }: ReduxStore) => (next: Next) => (action: PublicAction) => {
     let returnValue;
-    const config = { ...defaultConfig, ...customConfig };
+    const customQueryConfigFromAction = action.customQueryConfig || {};
+    const config = { ...defaultConfig, ...customConfig, ...customQueryConfigFromAction };
 
     switch (action.type) {
       case actionTypes.REQUEST_ASYNC: {

--- a/packages/redux-query/src/middleware/query.js
+++ b/packages/redux-query/src/middleware/query.js
@@ -29,7 +29,7 @@ import type {
   ResponseBody,
   Status,
   Transform,
-  Config,
+  QueryMiddlewareConfig,
 } from '../types';
 
 type ReduxStore = {|
@@ -39,7 +39,7 @@ type ReduxStore = {|
 
 type Next = (action: PublicAction) => any;
 
-const defaultConfig: Config = {
+const defaultConfig: QueryMiddlewareConfig = {
   backoff: {
     maxAttempts: 5,
     minDuration: 300,
@@ -97,8 +97,8 @@ const queryMiddleware = (
 
   return ({ dispatch, getState }: ReduxStore) => (next: Next) => (action: PublicAction) => {
     let returnValue;
-    const customQueryConfigFromAction = action.customQueryConfig || {};
-    const config = { ...defaultConfig, ...customConfig, ...customQueryConfigFromAction };
+    const customQueryMiddlewareConfigFromAction = action.customQueryMiddlewareConfig || {};
+    const config = { ...defaultConfig, ...customConfig, ...customQueryMiddlewareConfigFromAction };
 
     switch (action.type) {
       case actionTypes.REQUEST_ASYNC: {

--- a/packages/redux-query/src/types.js
+++ b/packages/redux-query/src/types.js
@@ -13,7 +13,7 @@ type QueryOptions = {
   headers?: { [key: string]: any },
 };
 
-export type Config = {|
+export type QueryMiddlewareConfig = {|
   backoff: {|
     maxAttempts: number,
     minDuration: number,
@@ -35,7 +35,7 @@ export type QueryConfig = {|
   rollback?: { [key: string]: (initialValue: any, currentValue: any) => any },
   unstable_preDispatchCallback?: () => void,
   url: Url,
-  customQueryConfig?: Config,
+  customQueryMiddlewareConfig?: QueryMiddlewareConfig,
 |};
 
 export type QueryDetails = {

--- a/packages/redux-query/src/types.js
+++ b/packages/redux-query/src/types.js
@@ -13,6 +13,15 @@ type QueryOptions = {
   headers?: { [key: string]: any },
 };
 
+export type Config = {|
+  backoff: {|
+    maxAttempts: number,
+    minDuration: number,
+    maxDuration: number,
+  |},
+  retryableStatusCodes: Array<Status>,
+|};
+
 export type QueryConfig = {|
   body?: RequestBody,
   force?: boolean,
@@ -26,6 +35,7 @@ export type QueryConfig = {|
   rollback?: { [key: string]: (initialValue: any, currentValue: any) => any },
   unstable_preDispatchCallback?: () => void,
   url: Url,
+  customQueryConfig?: Config,
 |};
 
 export type QueryDetails = {


### PR DESCRIPTION
`customQueryMiddlewareConfig` is the same as middleware config, but it can be applied per request

**Does not have tests, so should be rolled out as RC deployment**